### PR TITLE
Added support for special nodes that only send when data is ready

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ license = "MIT"
 [dependencies]
 crossbeam = "0.4"
 crossbeam-channel = "0.2"
+rand = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate crossbeam;
 extern crate crossbeam_channel;
+extern crate rand;
 
 #[macro_use]
 pub mod node;


### PR DESCRIPTION
- A new macro: create_aggregate_node! constructs nodes that must output
  Option types. Data is only sent from the transformation function if
  the data is not None. If the data is None, the node just moves to the
  next iteration.
- Fixed errors in the testing framework where the asserts weren't
  actually running since the main thread would terminate and not wait
  for the children thread to finish.
- Added a test case for aggregate nodes and a very rudimentary test case
  to get some estimates of message throughput through the nodes to see
  if crossbeam will work for our particular use case.