### PR TITLE
Adding support for documentation in macros.

### DIFF
--- a/src/fft/fft_node.rs
+++ b/src/fft/fft_node.rs
@@ -8,6 +8,9 @@ use rustfft::{FFTplanner, FFT};
 use std::sync::Arc;
 
 create_node!(
+    #[doc="A node that supports FFTs and IFFTs. FFTs are done in batch: the "]
+    #[doc="node expects that input data matching the specified FFT size is "]
+    #[doc="provided."]
     FFTBatchNode<T>: Vec<Complex<T>> where T: NumCast + Clone + Num,
     [fft: Arc<FFT<f64>>, fft_size: usize],
     [recv: Vec<Complex<T>>],
@@ -40,6 +43,25 @@ where
     }
 }
 
+/// Constructs a node that performs FFT or IFFTs in batches.
+///
+/// Example:
+/// ```
+/// # extern crate comms_rs;
+/// # #[macro_use] use comms_rs::node::Node;
+/// # use comms_rs::{channel, Receiver, Sender};
+/// # fn main() {
+/// use comms_rs::fft::fft_node::{self, FFTBatchNode};
+///
+/// // Sets up an FFT that receives 1024 Complex<i16> samples and performs
+/// // an FFT on those samples.
+/// let mut fft_node: FFTBatchNode<i16> = fft_node::fft_batch_node(1024, false);
+///
+/// // Sets up an IFFT that receives 1024 Complex<f32> complex samples and performs
+/// // an IFFT on those samples.
+/// let mut ifft_node: FFTBatchNode<f32> = fft_node::fft_batch_node(1024, true);
+/// # }
+///
 pub fn fft_batch_node<T: NumCast + Clone + Num>(
     fft_size: usize,
     ifft: bool,
@@ -50,6 +72,9 @@ pub fn fft_batch_node<T: NumCast + Clone + Num>(
 }
 
 create_node!(
+    #[doc="A node that supports FFTs and IFFTs. This node expects data to be "]
+    #[doc="provided sample by sample and will only perform the FFT once it "]
+    #[doc="has received enough samples specified by fft_size."]
     FFTSampleNode<T>: Option<Vec<Complex<T>>> where T: NumCast + Clone + Num,
     [fft: Arc<FFT<f64>>, fft_size: usize, samples: Vec<Complex<T>>],
     [recv: Complex<T>],
@@ -88,6 +113,25 @@ where
     }
 }
 
+/// Constructs a node that performs FFT or IFFTs, but only receives a sample
+/// at a time versus a batch of samples.
+///
+/// Example:
+/// ```
+/// # extern crate comms_rs;
+/// # #[macro_use] use comms_rs::node::Node;
+/// # use comms_rs::{channel, Receiver, Sender};
+/// # fn main() {
+/// use comms_rs::fft::fft_node::{self, FFTSampleNode};
+///
+/// // Sets up an FFT that receives 1024 Complex<i16> samples and performs
+/// // an FFT on those samples.
+/// let mut fft_node: FFTSampleNode<i16> = fft_node::fft_sample_node(1024, false);
+///
+/// // Sets up an IFFT that receives 1024 Complex<f32> complex samples and performs
+/// // an IFFT on those samples.
+/// let mut ifft_node: FFTSampleNode<f32> = fft_node::fft_sample_node(1024, true);
+/// # }
 pub fn fft_sample_node<T: NumCast + Clone + Num>(
     fft_size: usize,
     ifft: bool,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -108,8 +108,9 @@ pub trait Node {
 /// ```
 #[macro_export]
 macro_rules! create_node {
-    ($name:ident: Option<$out:ty>, [$($state:ident: $type:ty),*], 
+    ($(#[$attr:meta])* $name:ident: Option<$out:ty>, [$($state:ident: $type:ty),*], 
      [$($recv:ident: $in:ty),*], $func:expr) => {
+        $(#[$attr])*
         pub struct $name {
             $(
                 pub $recv: Option<Receiver<$in>>,
@@ -130,9 +131,10 @@ macro_rules! create_node {
         }
     };
 
-    ($name:ident<$($gen:ident),+>: Option<$out:ty>,
+    ($(#[$attr:meta])* $name:ident<$($gen:ident),+>: Option<$out:ty>,
      [$($state:ident: $type:ty),*],
      [$($recv:ident: $in:ty),*], $func:expr) => {
+        $(#[$attr])*
         pub struct $name<$($gen,)+> {
             $(
                 pub $recv: Option<Receiver<$in>>,
@@ -153,9 +155,10 @@ macro_rules! create_node {
         }
     };
 
-    ($name:ident<$($gen:ident),+>: Option<$out:ty> where
+    ($(#[$attr:meta])* $name:ident<$($gen:ident),+>: Option<$out:ty> where
      $($gen_t:ident: $where:ident $(+ $where_rep:ident)*,)+
      [$($state:ident: $type:ty),*], [$($recv:ident: $in:ty),*], $func:expr) => {
+        $(#[$attr])*
         pub struct $name<$($gen,)+>
         where $( $gen_t: $where $(+ ($where_rep))*, )+
         {
@@ -180,8 +183,9 @@ macro_rules! create_node {
             generate_aggregate_call!($func, $out, $($recv),*);
         }
     };
-    ($name:ident: $out:ty, [$($state:ident: $type:ty),*],
+    ($(#[$attr:meta])* $name:ident: $out:ty, [$($state:ident: $type:ty),*],
      [$($recv:ident: $in:ty),*], $func:expr) => {
+        $(#[$attr])*
         pub struct $name {
             $(
                 pub $recv: Option<Receiver<$in>>,
@@ -202,8 +206,9 @@ macro_rules! create_node {
         }
     };
 
-    ($name:ident<$($gen:ident),+>: $out:ty, [$($state:ident: $type:ty),*],
+    ($(#[$attr:meta])* $name:ident<$($gen:ident),+>: $out:ty, [$($state:ident: $type:ty),*],
      [$($recv:ident: $in:ty),*], $func:expr) => {
+        $(#[$attr])*
         pub struct $name<$($gen,)+> {
             $(
                 pub $recv: Option<Receiver<$in>>,
@@ -224,9 +229,10 @@ macro_rules! create_node {
         }
     };
 
-    ($name:ident<$($gen:ident),+>: $out:ty where
+    ($(#[$attr:meta])* $name:ident<$($gen:ident),+>: $out:ty where
      $($gen_t:ident: $where:ident $(+ $where_rep:ident)*,)+
      [$($state:ident: $type:ty),*], [$($recv:ident: $in:ty),*], $func:expr) => {
+        $(#[$attr])*
         pub struct $name<$($gen,)+>
         where $( $gen_t: $where $(+ ($where_rep))*, )+
         {

--- a/src/util/rand_node.rs
+++ b/src/util/rand_node.rs
@@ -4,8 +4,8 @@ use rand::distributions::uniform::SampleUniform;
 use rand::distributions::{Normal, Uniform};
 use rand::{FromEntropy, Rng, StdRng};
 
-/// A node that will generate uniformly-distributed random numbers.
 create_node!(
+    #[doc="A node that will generate uniformly-distributed random numbers."]
     UniformNode<T>: T where T: SampleUniform + Clone,
     [rng: StdRng, dist: Uniform<T>],
     [],
@@ -14,8 +14,8 @@ create_node!(
     }
 );
 
-/// A node that will generate normally-distributed random numbers.
 create_node!(
+    #[doc="A node that will generate normally-distributed random numbers."]
     NormalNode: f64,
     [rng: StdRng, dist: Normal],
     [],


### PR DESCRIPTION
- Using the #[doc] attribute, comments can now be attached to nodes when constructed via the create_node! macro. 
- Added some documentation for some of the nodes I've generated as an example.
- Added more documentation to the FFT nodes.