### PR TITLE
RTL-SDR support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ crossbeam = "0.4"
 crossbeam-channel = "0.2"
 rand = "0.5"
 rustfft = "2.1"
-rtlsdr = "0.1"
+rtlsdr = {version = "0.1", optional = true}
 
 [features]
-rtlsdr_support = []
+rtlsdr_support = ["rtlsdr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,13 @@ keywords = ["dsp", "rf"]
 license = "MIT"
 
 [dependencies]
-num = "0.2.0"
-num-complex = "0.2.0"
+num = "0.2"
+num-complex = "0.2"
 crossbeam = "0.4"
 crossbeam-channel = "0.2"
 rand = "0.5"
-rustfft = "2.1.0"
+rustfft = "2.1"
+rtlsdr = "0.1"
+
+[features]
+rtlsdr_support = []

--- a/src/fft/fft_node.rs
+++ b/src/fft/fft_node.rs
@@ -1,8 +1,8 @@
 use crossbeam::{Receiver, Sender};
 use node::Node;
 use num::NumCast;
-use rustfft::num_traits::Num;
 use rustfft::num_complex::Complex;
+use rustfft::num_traits::Num;
 use rustfft::num_traits::Zero;
 use rustfft::{FFTplanner, FFT};
 use std::sync::Arc;
@@ -37,8 +37,9 @@ where
         // After the FFT, convert back to interleaved values.
         let res: Vec<Complex<T>> = output
             .iter()
-            .map(|x| Complex::new(T::from(x.re).unwrap(), T::from(x.im).unwrap()))
-            .collect();
+            .map(|x| {
+                Complex::new(T::from(x.re).unwrap(), T::from(x.im).unwrap())
+            }).collect();
         res
     }
 }
@@ -95,7 +96,8 @@ where
     T: NumCast + Clone + Num,
 {
     fn run_fft(&mut self) -> Vec<Complex<T>> {
-        let mut input: Vec<Complex<f64>> = self.samples
+        let mut input: Vec<Complex<f64>> = self
+            .samples
             .iter()
             .map(|x| {
                 Complex::new(x.re.to_f64().unwrap(), x.im.to_f64().unwrap())
@@ -107,8 +109,9 @@ where
         // After the FFT, convert back to interleaved values.
         let res: Vec<Complex<T>> = output
             .iter()
-            .map(|x| Complex::new(T::from(x.re).unwrap(), T::from(x.im).unwrap()))
-            .collect();
+            .map(|x| {
+                Complex::new(T::from(x.re).unwrap(), T::from(x.im).unwrap())
+            }).collect();
         res
     }
 }
@@ -147,32 +150,27 @@ mod test {
     use crossbeam_channel as channel;
     use fft::fft_node;
     use node::Node;
+    use rustfft::num_complex::Complex;
     use std::thread;
     use std::time::Instant;
-    use rustfft::num_complex::Complex;
 
     #[test]
     fn test_fft_batch() {
-        create_node!(
-            SendNode: Vec<Complex<f32>>,
-            [],
-            [],
-            |_| {
-                let input = vec![
-                    Complex::new(0.1, 0.1),
-                    Complex::new(0.2, 0.2),
-                    Complex::new(0.3, 0.3),
-                    Complex::new(0.4, 0.4),
-                    Complex::new(0.5, 0.5),
-                    Complex::new(0.6, 0.6),
-                    Complex::new(0.7, 0.7),
-                    Complex::new(0.8, 0.8),
-                    Complex::new(0.9, 0.9),
-                    Complex::new(1.0, 1.0),
-                ];
-                input
-            }
-        );
+        create_node!(SendNode: Vec<Complex<f32>>, [], [], |_| {
+            let input = vec![
+                Complex::new(0.1, 0.1),
+                Complex::new(0.2, 0.2),
+                Complex::new(0.3, 0.3),
+                Complex::new(0.4, 0.4),
+                Complex::new(0.5, 0.5),
+                Complex::new(0.6, 0.6),
+                Complex::new(0.7, 0.7),
+                Complex::new(0.8, 0.8),
+                Complex::new(0.9, 0.9),
+                Complex::new(1.0, 1.0),
+            ];
+            input
+        });
         let mut send_node = SendNode::new();
 
         let mut fft_node = fft_node::fft_batch_node(10, false);
@@ -222,9 +220,7 @@ mod test {
             SendNode: Option<Complex<f32>>,
             [input: Vec<Complex<f32>>],
             [],
-            |node: &mut SendNode| {
-                node.input.pop()
-            }
+            |node: &mut SendNode| node.input.pop()
         );
 
         let input = vec![

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -1,3 +1,1 @@
-use crossbeam::{Receiver, Sender};
-
 pub mod fft_node;

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -1,1 +1,3 @@
+extern crate rtlsdr;
 
+pub mod rtlsdr_node;

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "rtlsdr_support")]
 extern crate rtlsdr;
 
+#[cfg(feature = "rtlsdr_support")]
 pub mod rtlsdr_node;

--- a/src/hardware/rtlsdr_node.rs
+++ b/src/hardware/rtlsdr_node.rs
@@ -1,0 +1,108 @@
+use crossbeam::Sender;
+use hardware::rtlsdr::{self, RTLSDRDevice, RTLSDRError};
+use node::Node;
+
+pub struct RTLSDR {
+    rtlsdr: RTLSDRDevice,
+}
+
+// The default implementation for the RTLSDR in the library doesn't implement
+// Send so it isn't thread-safe. We wrap it up here as Send so we can throw
+// it in the nodes.
+unsafe impl Send for RTLSDR {}
+
+create_node!(
+    #[doc = "An interface for the RTL-SDR."]
+    RTLSDRNode: Vec<u8>,
+    [sdr: RTLSDR, num_samples: usize],
+    [],
+    |node: &mut RTLSDRNode| node.get_samples()
+);
+
+impl RTLSDRNode {
+    /// Configure the radio for operation. Make sure to run this before
+    /// running get_samples, otherwise get_samples will fail and output
+    /// an empty vector.
+    pub fn init_radio(
+        &mut self,
+        freq: u32,
+        sample_rate: u32,
+        gain: i32,
+    ) -> Result<(), RTLSDRError> {
+        self.sdr.rtlsdr.set_center_freq(freq)?;
+        self.sdr.rtlsdr.set_sample_rate(sample_rate)?;
+        self.sdr.rtlsdr.set_tuner_gain(gain)?;
+        self.sdr.rtlsdr.reset_buffer()?;
+        Ok(())
+    }
+
+    /// Enables or disables the AGC on the RTLSDR.
+    pub fn set_agc(&mut self, agc_on: bool) -> Result<(), RTLSDRError> {
+        self.sdr.rtlsdr.set_agc_mode(agc_on)?;
+        Ok(())
+    }
+
+    /// Returns samples from the RTLSDR. If the connection fails for
+    /// whatever reason, an empty vector is sent out.
+    pub fn get_samples(&mut self) -> Vec<u8> {
+        match self.sdr.rtlsdr.read_sync(self.num_samples) {
+            Ok(samp) => samp,
+            Err(_) => vec![],
+        }
+    }
+}
+
+/// Constructs a node containing an open but uninitialized connection to an
+/// RTLSDR at the given index. Use RTLSDRNode::init_radio to set up the radio
+/// prior to running the node.
+pub fn rtlsdr(
+    index: i32,
+    num_samples: usize,
+) -> Result<RTLSDRNode, RTLSDRError> {
+    let rtlsdr = rtlsdr::open(index)?;
+    let sdr = RTLSDR { rtlsdr };
+    Ok(RTLSDRNode::new(sdr, num_samples))
+}
+
+#[cfg(test)]
+mod test {
+    use crossbeam::{channel, Receiver, Sender};
+    use hardware::rtlsdr_node;
+    use node::Node;
+    use std::thread;
+    use std::time::Instant;
+
+    #[test]
+    #[cfg_attr(not(feature = "rtlsdr_support"), ignore)]
+    // A quick test to check if we can read samples off the RTLSDR.
+    fn test_get_samples() {
+        let num_samples = 262144;
+        if let Ok(mut sdr_node) = rtlsdr_node::rtlsdr(0, num_samples) {
+            sdr_node.init_radio(88.7e6 as u32, 2.4e6 as u32, 0).unwrap();
+            sdr_node.set_agc(true).unwrap();
+            create_node!(
+                CheckNode: (),
+                [num_samples: usize],
+                [recv: Vec<u8>],
+                |node: &mut CheckNode, samples: Vec<u8>| {
+                    assert_eq!(samples.len(), node.num_samples);
+                }
+            );
+            let mut check_node = CheckNode::new(num_samples);
+            connect_nodes!(sdr_node, check_node, recv);
+            start_nodes!(sdr_node);
+            let check = thread::spawn(move || {
+                let now = Instant::now();
+                loop {
+                    check_node.call();
+                    if now.elapsed().as_secs() >= 1 {
+                        break;
+                    }
+                }
+            });
+            assert!(check.join().is_ok());
+        } else {
+            panic!("Couldn't connect to SDR.");
+        }
+    }
+}

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -108,7 +108,7 @@ pub trait Node {
 /// ```
 #[macro_export]
 macro_rules! create_node {
-    ($(#[$attr:meta])* $name:ident: Option<$out:ty>, [$($state:ident: $type:ty),*], 
+    ($(#[$attr:meta])* $name:ident: Option<$out:ty>, [$($state:ident: $type:ty),*],
      [$($recv:ident: $in:ty),*], $func:expr) => {
         $(#[$attr])*
         pub struct $name {

--- a/src/util/rand_node.rs
+++ b/src/util/rand_node.rs
@@ -15,7 +15,7 @@ create_node!(
 );
 
 create_node!(
-    #[doc="A node that will generate normally-distributed random numbers."]
+    #[doc = "A node that will generate normally-distributed random numbers."]
     NormalNode: f64,
     [rng: StdRng, dist: Normal],
     [],


### PR DESCRIPTION
Initial node for interfacing with the RTLSDR

- Creating the initial node to provide an interface for collecting
  samples off the RTL-SDR tuner.
- As the RTLSDR support requires a third-party library to be installed
  on the machine, we're making support for it optional. It can be
  enabled via the rtlsdr_support feature.
- Clippy and rustfmt updates.