### PR TITLE
Adding support for spawning nodes from a threadpool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ num-traits = "0.2"
 crossbeam = "0.4"
 crossbeam-channel = "0.2"
 rand = "0.5"
+rayon = "1"
 rodio = "0.8"
 rustfft = "2.1"
 rtlsdr = {version = "0.1", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate crossbeam_channel;
 extern crate num;
 extern crate num_traits;
 extern crate rand;
+extern crate rayon;
 extern crate rodio;
 extern crate rustfft;
 


### PR DESCRIPTION
- As some nodes may not be complicated enough to warrant running in its
  own thread, any node can now run from a Rayon threadpool via the
  `start_nodes_threadpool!` macro.