### PR TITLE
ZeroMQ Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
 language: rust
+sudo: false
 rust:
   - stable
   - beta
   - nightly
+addons:
+  apt:
+    packages:
+    - libasound2-dev
 matrix:
   allow_failures: nightly
 before_install:
-    sudo apt-get install libasound2-dev libzmq3-dev
+  - |
+    wget https://github.com/zeromq/zeromq4-1/archive/v4.1.6.tar.gz
+    tar zxf v4.1.6.tar.gz
+    cd zeromq4-1-4.1.6
+    ./autogen.sh
+    ./configure --prefix=$HOME
+    make
+    make install
+    cd ..
 script:
   - cargo build --release --verbose --all
   - cargo test --release --verbose --all --features=zmq_node
+env:
+  global:
+  - PATH=$HOME/.local/bin:$PATH
+  - LD_LIBRARY_PATH=$HOME/lib
+  - PKG_CONFIG_PATH=$HOME/lib/pkgconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
 matrix:
   allow_failures: nightly
 before_install:
-    sudo apt-get install libasound2-dev
+    sudo apt-get install libasound2-dev libzmq
 script:
   - cargo build --release --verbose --all
-  - cargo test --release --verbose --all
+  - cargo test --release --verbose --all --features=zmq_node

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
 matrix:
   allow_failures: nightly
 before_install:
-    sudo apt-get install libasound2-dev libzmq
+    sudo apt-get install libasound2-dev libzmq3-dev
 script:
   - cargo build --release --verbose --all
   - cargo test --release --verbose --all --features=zmq_node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rayon = "1"
 rodio = "0.8"
 rustfft = "2.1"
 rtlsdr = {version = "0.1", optional = true}
+zmq = "0.8"
 
 [features]
 rtlsdr_support = ["rtlsdr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ rayon = "1"
 rodio = "0.8"
 rustfft = "2.1"
 rtlsdr = {version = "0.1", optional = true}
+serde = "1"
+bincode = "1"
 zmq = {version = "0.8", optional = true}
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT"
 [dependencies]
 assert_approx_eq = "1.0"
 byteorder = "1"
-num = "0.2"
 num-complex = "0.2"
 num-traits = "0.2"
 crossbeam = "0.4"
@@ -25,6 +24,10 @@ rtlsdr = {version = "0.1", optional = true}
 serde = "1"
 bincode = "1"
 zmq = {version = "0.8", optional = true}
+
+[dependencies.num]
+version = "0.2"
+features = ["serde"]
 
 [features]
 rtlsdr_node = ["rtlsdr"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ rayon = "1"
 rodio = "0.8"
 rustfft = "2.1"
 rtlsdr = {version = "0.1", optional = true}
-zmq = "0.8"
+zmq = {version = "0.8", optional = true}
 
 [features]
-rtlsdr_support = ["rtlsdr"]
+rtlsdr_node = ["rtlsdr"]
+zmq_node = ["zmq"]

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -2,10 +2,10 @@
 //! radio functionality.
 //!
 
-#[cfg(feature = "rtlsdr_support")]
+#[cfg(feature = "rtlsdr_node")]
 extern crate rtlsdr;
 
-#[cfg(feature = "rtlsdr_support")]
+#[cfg(feature = "rtlsdr_node")]
 pub mod rtlsdr_radio;
 
 pub mod radio;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,2 +1,3 @@
 pub mod audio;
 pub mod raw_iq;
+pub mod zmq;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,3 +1,8 @@
+#[cfg(feature = "zmq_node")]
+extern crate zmq;
+
 pub mod audio;
 pub mod raw_iq;
-pub mod zmq;
+
+#[cfg(feature = "zmq_node")]
+pub mod zmq_node;

--- a/src/io/zmq.rs
+++ b/src/io/zmq.rs
@@ -1,0 +1,40 @@
+use prelude::*;
+use zmq::Socket;
+use byteorder::ReadBytesExt;
+
+create_node!(
+    ZMQSend<T>: (),
+    [socket: Socket, flags: i32],
+    [recv: T],
+    |node: &mut ZMQSend<T>, mut data: T| {
+        node.send(&mut data);
+    },
+    T: ReadBytesExt,
+);
+
+impl<T> ZMQSend<T>
+where
+    T: ReadBytesExt
+{
+    pub fn send(&mut self, data: &mut T) {
+        let mut buffer = vec![];
+        data.read_to_end(&mut buffer).unwrap();
+        self.socket.send(&buffer, self.flags).unwrap()
+    }
+}
+
+create_node!(
+    ZMQRecv: Vec<u8>,
+    [socket: Socket, flags: i32],
+    [],
+    |node: &mut ZMQRecv| {
+        node.recv()
+    }
+);
+
+impl ZMQRecv
+{
+    pub fn recv(&mut self) -> Vec<u8> {
+        self.socket.recv_bytes(self.flags).unwrap()
+    }
+}

--- a/src/io/zmq_node.rs
+++ b/src/io/zmq_node.rs
@@ -1,6 +1,6 @@
-use prelude::*;
-use zmq::Socket;
 use byteorder::ReadBytesExt;
+use io::zmq::Socket;
+use prelude::*;
 
 create_node!(
     ZMQSend<T>: (),
@@ -14,7 +14,7 @@ create_node!(
 
 impl<T> ZMQSend<T>
 where
-    T: ReadBytesExt
+    T: ReadBytesExt,
 {
     pub fn send(&mut self, data: &mut T) {
         let mut buffer = vec![];
@@ -27,13 +27,10 @@ create_node!(
     ZMQRecv: Vec<u8>,
     [socket: Socket, flags: i32],
     [],
-    |node: &mut ZMQRecv| {
-        node.recv()
-    }
+    |node: &mut ZMQRecv| node.recv()
 );
 
-impl ZMQRecv
-{
+impl ZMQRecv {
     pub fn recv(&mut self) -> Vec<u8> {
         self.socket.recv_bytes(self.flags).unwrap()
     }

--- a/src/io/zmq_node.rs
+++ b/src/io/zmq_node.rs
@@ -1,37 +1,97 @@
-use byteorder::ReadBytesExt;
-use io::zmq::Socket;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use bincode::{serialize, deserialize};
+use io::zmq;
 use prelude::*;
 
 create_node!(
     ZMQSend<T>: (),
-    [socket: Socket, flags: i32],
-    [recv: T],
-    |node: &mut ZMQSend<T>, mut data: T| {
+    [socket: zmq::Socket, flags: i32],
+    [recv: Vec<T>],
+    |node: &mut ZMQSend<T>, mut data: Vec<T>| {
         node.send(&mut data);
     },
-    T: ReadBytesExt,
+    T: Serialize + Clone,
 );
 
 impl<T> ZMQSend<T>
 where
-    T: ReadBytesExt,
+    T: Serialize + Clone,
 {
-    pub fn send(&mut self, data: &mut T) {
-        let mut buffer = vec![];
-        data.read_to_end(&mut buffer).unwrap();
-        self.socket.send(&buffer, self.flags).unwrap()
+    pub fn send(&mut self, data: &mut Vec<T>) {
+        let buffer: Vec<u8> = serialize(&data).unwrap();
+        self.socket.send(&buffer, self.flags).unwrap();
     }
 }
 
 create_node!(
-    ZMQRecv: Vec<u8>,
-    [socket: Socket, flags: i32],
+    ZMQRecv<T>: Vec<T>,
+    [socket: zmq::Socket, flags: i32],
     [],
-    |node: &mut ZMQRecv| node.recv()
+    |node: &mut ZMQRecv<T>| node.recv(),
+    T: DeserializeOwned + Clone,
 );
 
-impl ZMQRecv {
-    pub fn recv(&mut self) -> Vec<u8> {
-        self.socket.recv_bytes(self.flags).unwrap()
+impl<T> ZMQRecv<T>
+where
+    T: DeserializeOwned + Clone,
+{
+    pub fn recv(&mut self) -> Vec<T> {
+        println!("We got a thing");
+        let bytes = self.socket.recv_bytes(self.flags).unwrap();
+        let res: Vec<T> = deserialize(&bytes).unwrap();
+        res
+    }
+}
+
+pub fn zmq_recv<T>(socket_type: zmq::SocketType, flags: i32) -> ZMQRecv<T> 
+where 
+    T: DeserializeOwned + Clone,
+{
+    let context = zmq::Context::new();
+    let socket = context.socket(socket_type).unwrap();
+    ZMQRecv::new(socket, flags)
+}
+
+pub fn zmq_send<T>(socket_type: zmq::SocketType, flags: i32) -> ZMQSend<T>
+where
+    T: Serialize + Clone,
+{
+    let context = zmq::Context::new();
+    let socket = context.socket(socket_type).unwrap();
+    ZMQSend::new(socket, flags)
+}
+
+#[cfg(test)]
+mod test {
+    use byteorder::{NativeEndian, ReadBytesExt};
+    use io::zmq_node;
+    use prelude::*;
+    use std::io::Cursor;
+    use std::thread;
+    use io::zmq;
+
+    #[test]
+    fn test_zmq() {
+        create_node!(DataGen: Vec<u32>, [], [], |_| vec![1, 2, 3, 4, 5],);
+        let mut data_node = DataGen::new();
+        let mut zmq_send = zmq_node::zmq_send::<u32>(zmq::SocketType::PUB, 0);
+        let mut zmq_recv = zmq_node::zmq_recv(zmq::SocketType::SUB, 0);
+        create_node!(CheckNode: (), [], [recv: Vec<u8>], |_, data: Vec<u8>| {
+            let mut cursor = Cursor::new(data);
+            let mut dst = [0; 5];
+            cursor.read_u32_into::<NativeEndian>(&mut dst).unwrap();
+            assert_eq!(dst, [1, 2, 3, 4, 5]);
+        });
+        let mut check_node = CheckNode::new();
+        connect_nodes!(data_node, zmq_send, recv);
+        connect_nodes!(zmq_recv, check_node, recv);
+        start_nodes!(data_node, zmq_send, zmq_recv);
+
+        let handle = thread::spawn(move || {
+            check_node.call();
+        });
+
+        assert!(handle.join().is_ok());
     }
 }

--- a/src/io/zmq_node.rs
+++ b/src/io/zmq_node.rs
@@ -1,14 +1,14 @@
-use serde::Serialize;
-use serde::de::DeserializeOwned;
-use bincode::{serialize, deserialize};
+use bincode::{deserialize, serialize};
 use io::zmq;
 use prelude::*;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 create_node!(
     ZMQSend<T>: (),
     [socket: zmq::Socket, flags: i32],
-    [recv: Vec<T>],
-    |node: &mut ZMQSend<T>, mut data: Vec<T>| {
+    [recv: T],
+    |node: &mut ZMQSend<T>, mut data: T| {
         node.send(&mut data);
     },
     T: Serialize + Clone,
@@ -18,14 +18,14 @@ impl<T> ZMQSend<T>
 where
     T: Serialize + Clone,
 {
-    pub fn send(&mut self, data: &mut Vec<T>) {
+    pub fn send(&mut self, data: &mut T) {
         let buffer: Vec<u8> = serialize(&data).unwrap();
         self.socket.send(&buffer, self.flags).unwrap();
     }
 }
 
 create_node!(
-    ZMQRecv<T>: Vec<T>,
+    ZMQRecv<T>: T,
     [socket: zmq::Socket, flags: i32],
     [],
     |node: &mut ZMQRecv<T>| node.recv(),
@@ -36,53 +36,70 @@ impl<T> ZMQRecv<T>
 where
     T: DeserializeOwned + Clone,
 {
-    pub fn recv(&mut self) -> Vec<T> {
-        println!("We got a thing");
+    pub fn recv(&mut self) -> T {
         let bytes = self.socket.recv_bytes(self.flags).unwrap();
-        let res: Vec<T> = deserialize(&bytes).unwrap();
+        let res: T = deserialize(&bytes).unwrap();
         res
     }
 }
 
-pub fn zmq_recv<T>(socket_type: zmq::SocketType, flags: i32) -> ZMQRecv<T> 
-where 
+pub fn zmq_recv<T>(
+    endpoint: &str,
+    socket_type: zmq::SocketType,
+    flags: i32,
+) -> ZMQRecv<T>
+where
     T: DeserializeOwned + Clone,
 {
     let context = zmq::Context::new();
     let socket = context.socket(socket_type).unwrap();
+    socket.connect(endpoint).unwrap();
+    socket.set_subscribe(&[]).unwrap();
     ZMQRecv::new(socket, flags)
 }
 
-pub fn zmq_send<T>(socket_type: zmq::SocketType, flags: i32) -> ZMQSend<T>
+pub fn zmq_send<T>(
+    endpoint: &str,
+    socket_type: zmq::SocketType,
+    flags: i32,
+) -> ZMQSend<T>
 where
     T: Serialize + Clone,
 {
     let context = zmq::Context::new();
     let socket = context.socket(socket_type).unwrap();
+    socket.bind(endpoint).unwrap();
     ZMQSend::new(socket, flags)
 }
 
 #[cfg(test)]
 mod test {
     use byteorder::{NativeEndian, ReadBytesExt};
+    use io::zmq;
     use io::zmq_node;
     use prelude::*;
     use std::io::Cursor;
     use std::thread;
-    use io::zmq;
 
     #[test]
     fn test_zmq() {
         create_node!(DataGen: Vec<u32>, [], [], |_| vec![1, 2, 3, 4, 5],);
         let mut data_node = DataGen::new();
-        let mut zmq_send = zmq_node::zmq_send::<u32>(zmq::SocketType::PUB, 0);
-        let mut zmq_recv = zmq_node::zmq_recv(zmq::SocketType::SUB, 0);
-        create_node!(CheckNode: (), [], [recv: Vec<u8>], |_, data: Vec<u8>| {
-            let mut cursor = Cursor::new(data);
-            let mut dst = [0; 5];
-            cursor.read_u32_into::<NativeEndian>(&mut dst).unwrap();
-            assert_eq!(dst, [1, 2, 3, 4, 5]);
-        });
+        let mut zmq_send =
+            zmq_node::zmq_send::<Vec<u32>>("tcp://*:5556", zmq::SocketType::PUB, 0);
+        let mut zmq_recv = zmq_node::zmq_recv::<Vec<u32>>(
+            "tcp://localhost:5556",
+            zmq::SocketType::SUB,
+            0,
+        );
+        create_node!(
+            CheckNode: (),
+            [],
+            [recv: Vec<u32>],
+            |_, data: Vec<u32>| {
+                assert_eq!(&data, &[1, 2, 3, 4, 5]);
+            }
+        );
         let mut check_node = CheckNode::new();
         connect_nodes!(data_node, zmq_send, recv);
         connect_nodes!(zmq_recv, check_node, recv);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate rand;
 extern crate rayon;
 extern crate rodio;
 extern crate rustfft;
+extern crate zmq;
 
 #[macro_use]
 pub mod node;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@
 // here: https://github.com/rust-lang-nursery/rust-clippy/issues/1553.
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_closure_call))]
 
-extern crate byteorder;
 extern crate bincode;
+extern crate byteorder;
 extern crate crossbeam;
 extern crate crossbeam_channel;
 extern crate num;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(redundant_closure_call))]
 
 extern crate byteorder;
+extern crate bincode;
 extern crate crossbeam;
 extern crate crossbeam_channel;
 extern crate num;
@@ -11,6 +12,7 @@ extern crate rand;
 extern crate rayon;
 extern crate rodio;
 extern crate rustfft;
+extern crate serde;
 
 #[macro_use]
 pub mod node;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ extern crate rand;
 extern crate rayon;
 extern crate rodio;
 extern crate rustfft;
-extern crate zmq;
 
 #[macro_use]
 pub mod node;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,3 +2,4 @@
 
 pub use crossbeam::{channel, Receiver, Sender};
 pub use node::Node;
+pub use std::thread;


### PR DESCRIPTION
- Adds two nodes: one for sending and one for receiving via ZeroMQ. Tested with PUB/SUB. Serializes and deserializes with serde and bincode, so the nodes can arbitrarily send data.