### PR TITLE
Removing the automatic new() implementation from the node derive macro.

### DIFF
--- a/examples/fm_radio.rs
+++ b/examples/fm_radio.rs
@@ -2,7 +2,7 @@
 extern crate comms_rs;
 extern crate num;
 
-use comms_rs::filter::fir_node::{batch_fir_node, BatchFirNode};
+use comms_rs::filter::fir_node::BatchFirNode;
 use comms_rs::hardware::{self, radio};
 use comms_rs::io::audio;
 use comms_rs::modulation::analog_node;
@@ -67,6 +67,13 @@ fn main() {
     }
 
     impl ConvertNode {
+        pub fn new() -> Self {
+            ConvertNode {
+                input: Default::default(),
+                sender: Default::default(),
+            }
+        }
+
         pub fn run(
             &mut self,
             samples: &[u8],
@@ -94,6 +101,13 @@ fn main() {
     }
 
     impl Convert2Node {
+        pub fn new() -> Self {
+            Convert2Node {
+                input: Default::default(),
+                sender: Default::default(),
+            }
+        }
+
         pub fn run(
             &mut self,
             samples: &[f32],
@@ -112,6 +126,13 @@ fn main() {
     }
 
     impl Convert3Node {
+        pub fn new() -> Self {
+            Convert3Node {
+                input: Default::default(),
+                sender: Default::default(),
+            }
+        }
+
         pub fn run(
             &mut self,
             samples: &[Complex<f32>],
@@ -123,13 +144,13 @@ fn main() {
     let mut sdr = radio::RadioRxNode::new(rtlsdr, 0, 262144);
     let mut convert = ConvertNode::new();
     let mut dec1: DecimateNode<Complex<f32>> = DecimateNode::new(5);
-    let mut filt1: BatchFirNode<f32> = batch_fir_node(taps.clone());
-    let mut fm = analog_node::fm_demod_node();
+    let mut filt1: BatchFirNode<f32> = BatchFirNode::new(taps.clone(), None);
+    let mut fm = analog_node::FMDemodNode::new();
     let mut convert2 = Convert2Node::new();
-    let mut filt2: BatchFirNode<f32> = batch_fir_node(taps);
+    let mut filt2: BatchFirNode<f32> = BatchFirNode::new(taps, None);
     let mut convert3 = Convert3Node::new();
     let mut dec2: DecimateNode<f32> = DecimateNode::new(5);
-    let mut audio: audio::AudioNode<f32> = audio::audio(1, 44100, 0.1);
+    let mut audio: audio::AudioNode<f32> = audio::AudioNode::new(1, 44100, 0.1);
 
     connect_nodes!(sdr, sender, convert, input);
     connect_nodes!(convert, sender, filt1, input);

--- a/examples/play_audio.rs
+++ b/examples/play_audio.rs
@@ -2,7 +2,7 @@
 extern crate comms_rs;
 extern crate crossbeam;
 extern crate rodio;
-use comms_rs::io::audio::{self, AudioNode};
+use comms_rs::io::audio::AudioNode;
 use comms_rs::prelude::*;
 use crossbeam::channel;
 use rodio::source::{self, Source};
@@ -10,7 +10,7 @@ use std::boxed::Box;
 use std::thread;
 
 fn main() {
-    let mut audio: AudioNode<f32> = audio::audio(1, 48000, 0.5);
+    let mut audio: AudioNode<f32> = AudioNode::new(1, 48000, 0.5);
 
     #[derive(Node)]
     struct SineNode {
@@ -19,6 +19,13 @@ fn main() {
     }
 
     impl SineNode {
+        pub fn new(source: Box<dyn Source<Item = f32> + Send>) -> Self {
+            SineNode {
+                source,
+                sender: Default::default(),
+            }
+        }
+
         pub fn run(&mut self) -> Result<Vec<f32>, NodeError> {
             let source = &mut self.source;
             let samp: Vec<f32> = source.take(48000).collect();

--- a/node_derive/src/lib.rs
+++ b/node_derive/src/lib.rs
@@ -56,10 +56,10 @@ pub fn node_derive(input: TokenStream) -> TokenStream {
     let mut pass_by_ref = false;
     for attr in attributes {
         match attr.parse_meta() {
-            Ok(syn::Meta::Word(ref id)) if id.to_string() == "aggregate" => {
+            Ok(syn::Meta::Word(ref id)) if *id == "aggregate" => {
                 aggregate = true
             }
-            Ok(syn::Meta::Word(ref id)) if id.to_string() == "pass_by_ref" => {
+            Ok(syn::Meta::Word(ref id)) if *id == "pass_by_ref" => {
                 pass_by_ref = true
             }
             Ok(_) => continue,
@@ -97,11 +97,6 @@ pub fn node_derive(input: TokenStream) -> TokenStream {
         .map(|x| x.ident.clone().unwrap())
         .collect();
 
-    let state_idents: Vec<syn::Ident> = state_fields
-        .iter()
-        .map(|x| x.ident.clone().unwrap())
-        .collect();
-
     // In order to stop quote from moving any variables and from complaining
     // about duplicates bindings in the macros, we need to build references for
     // each field we need.
@@ -110,21 +105,6 @@ pub fn node_derive(input: TokenStream) -> TokenStream {
     let recv_idents3 = &recv_idents;
     let send_idents1 = &send_idents;
     let send_idents2 = &send_idents;
-    let state_fields1 = &state_fields;
-    let state_idents1 = &state_idents;
-
-    let new_impl = quote! {
-        impl #impl_generics #name #ty_generics #where_clause {
-            pub fn new(#(#state_fields1,)*) -> #name #ty_generics {
-                #name {
-                    #(#recv_idents1: None,)*
-                    #(#send_idents1: vec![],)*
-                    #(#state_idents1,)*
-                }
-            }
-
-        }
-    };
 
     let run_func = if pass_by_ref {
         quote! {
@@ -213,7 +193,6 @@ pub fn node_derive(input: TokenStream) -> TokenStream {
     };
 
     let macro_out = quote! {
-        #new_impl
         #derive_node
     };
     macro_out.into()

--- a/src/filter/fir_node.rs
+++ b/src/filter/fir_node.rs
@@ -58,6 +58,59 @@ impl<T> FirNode<T>
 where
     T: Num + Copy,
 {
+    /// Constructs a new `FirNode<T>` with optional user defined initial state.
+    ///
+    /// # Arguments
+    ///
+    /// * `taps` - FIR filter tap Vec[Complex<T>].
+    /// * `state` - Initial state for the internal filter state and memory. If
+    ///    set to None, defaults to zeros.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use comms_rs::filter::fir_node::*;
+    /// use num::Complex;
+    ///
+    /// let taps = vec![
+    ///     Complex::new(0.2, 0.0),
+    ///     Complex::new(0.6, 0.0),
+    ///     Complex::new(0.6, 0.0),
+    ///     Complex::new(0.2, 0.0),
+    /// ];
+    ///
+    /// let mut state = vec![
+    ///     Complex::new(1.0, 0.0),
+    ///     Complex::new(0.5, 0.0),
+    ///     Complex::new(0.25, 0.0),
+    ///     Complex::new(0.125, 0.0),
+    /// ];
+    ///
+    /// let node = FirNode::new(taps, Some(state));
+    /// ```
+    pub fn new(
+        taps: Vec<Complex<T>>,
+        state: Option<Vec<Complex<T>>>,
+    ) -> Self {
+        match state {
+            Some(st) => FirNode {
+                taps,
+                st,
+                input: Default::default(),
+                output: Default::default(),
+            },
+            None => {
+                let len = taps.len();
+                FirNode {
+                    taps,
+                    state: vec![Complex::zero(); len],
+                    input: Default::default(),
+                    output: Default::default(),
+                }
+            }
+        }
+    }
+
     /// Runs the `FirNode<T>`.  Produces either a new `Complex<T>` sample or
     /// a `NodeError`.
     pub fn run(&mut self, input: &Complex<T>) -> Result<Complex<T>, NodeError> {
@@ -111,6 +164,60 @@ impl<T> BatchFirNode<T>
 where
     T: Num + Copy,
 {
+    /// Constructs a new `BatchFirNode<T>` with optional user defined initial
+    /// state.
+    ///
+    /// # Arguments
+    ///
+    /// * `taps` - FIR filter tap Vec[Complex<T>].
+    /// * `state` - Initial state for the internal filter state and memory. If
+    ///    set to None, defaults to zeros.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use comms_rs::filter::fir_node::*;
+    /// use num::Complex;
+    ///
+    /// let taps = vec![
+    ///     Complex::new(0.2, 0.0),
+    ///     Complex::new(0.6, 0.0),
+    ///     Complex::new(0.6, 0.0),
+    ///     Complex::new(0.2, 0.0),
+    /// ];
+    ///
+    /// let mut state = vec![
+    ///     Complex::new(1.0, 0.0),
+    ///     Complex::new(0.5, 0.0),
+    ///     Complex::new(0.25, 0.0),
+    ///     Complex::new(0.125, 0.0),
+    /// ];
+    ///
+    /// let node = BatchFirNode::new(taps, Some(state));
+    /// ```
+    pub fn new(
+        taps: Vec<Complex<T>>,
+        state: Option<Vec<Complex<T>>>,
+    ) -> Self {
+        match state {
+            Some(st) => BatchFirNode {
+                taps,
+                st,
+                input: Default::default(),
+                output: Default::default(),
+            },
+            None => {
+                let len = taps.len();
+                BatchFirNode {
+                    taps,
+                    state: vec![Complex::zero(); len],
+                    input: Default::default(),
+                    output: Default::default(),
+                }
+            }
+        }
+    }
+
     /// Runs the `BatchFirNode<T>`.  Produces either a new `Vec<Complex<T>>`
     /// batch of samples or a `NodeError`.
     pub fn run(
@@ -119,140 +226,6 @@ where
     ) -> Result<Vec<Complex<T>>, NodeError> {
         Ok(batch_fir(input, &self.taps, &mut self.state))
     }
-}
-
-/// Constructs a new `FirNode<T>` with initial state set to zeros.
-///
-/// # Arguments
-///
-/// * `taps` - FIR filter tap Vec[Complex<T>].
-///
-/// # Examples
-///
-/// ```
-/// use comms_rs::filter::fir_node::*;
-/// use num::Complex;
-///
-/// let taps = vec![
-///     Complex::new(0.2, 0.0),
-///     Complex::new(0.6, 0.0),
-///     Complex::new(0.6, 0.0),
-///     Complex::new(0.2, 0.0),
-/// ];
-/// let node = fir_node(taps);
-/// ```
-pub fn fir_node<T>(taps: Vec<Complex<T>>) -> FirNode<T>
-where
-    T: Num + Copy,
-{
-    let len = taps.len();
-    FirNode::new(taps, vec![Complex::zero(); len])
-}
-
-/// Constructs a new `FirNode<T>` with user defined initial state.
-///
-/// # Arguments
-///
-/// * `taps` - FIR filter tap Vec[Complex<T>].
-/// * `state` - Initial state for the internal filter state and memory.
-///
-/// # Examples
-///
-/// ```
-/// use comms_rs::filter::fir_node::*;
-/// use num::Complex;
-///
-/// let taps = vec![
-///     Complex::new(0.2, 0.0),
-///     Complex::new(0.6, 0.0),
-///     Complex::new(0.6, 0.0),
-///     Complex::new(0.2, 0.0),
-/// ];
-///
-/// let mut state = vec![
-///     Complex::new(1.0, 0.0),
-///     Complex::new(0.5, 0.0),
-///     Complex::new(0.25, 0.0),
-///     Complex::new(0.125, 0.0),
-/// ];
-///
-/// let node = fir_node_with_state(taps, state);
-/// ```
-pub fn fir_node_with_state<T>(
-    taps: Vec<Complex<T>>,
-    state: Vec<Complex<T>>,
-) -> FirNode<T>
-where
-    T: Num + Copy,
-{
-    FirNode::new(taps, state)
-}
-
-/// Constructs a new `BatchFirNode<T>` with initial state set to zeros.
-///
-/// # Arguments
-///
-/// * `taps` - FIR filter tap Vec[Complex<T>].
-///
-/// # Examples
-///
-/// ```
-/// use comms_rs::filter::fir_node::*;
-/// use num::Complex;
-///
-/// let taps = vec![
-///     Complex::new(0.2, 0.0),
-///     Complex::new(0.6, 0.0),
-///     Complex::new(0.6, 0.0),
-///     Complex::new(0.2, 0.0),
-/// ];
-/// let node = batch_fir_node(taps);
-/// ```
-pub fn batch_fir_node<T>(taps: Vec<Complex<T>>) -> BatchFirNode<T>
-where
-    T: Num + Copy,
-{
-    let len = taps.len();
-    BatchFirNode::new(taps, vec![Complex::zero(); len])
-}
-
-/// Constructs a new `BatchFirNode<T>` with user defined initial state.
-///
-/// # Arguments
-///
-/// * `taps` - FIR filter tap Vec[Complex<T>].
-/// * `state` - Initial state for the internal filter state and memory.
-///
-/// # Examples
-///
-/// ```
-/// use comms_rs::filter::fir_node::*;
-/// use num::Complex;
-///
-/// let taps = vec![
-///     Complex::new(0.2, 0.0),
-///     Complex::new(0.6, 0.0),
-///     Complex::new(0.6, 0.0),
-///     Complex::new(0.2, 0.0),
-/// ];
-///
-/// let mut state = vec![
-///     Complex::new(1.0, 0.0),
-///     Complex::new(0.5, 0.0),
-///     Complex::new(0.25, 0.0),
-///     Complex::new(0.125, 0.0),
-/// ];
-///
-/// let node = batch_fir_node_with_state(taps, state);
-/// ```
-pub fn batch_fir_node_with_state<T>(
-    taps: Vec<Complex<T>>,
-    state: Vec<Complex<T>>,
-) -> BatchFirNode<T>
-where
-    T: Num + Copy,
-{
-    BatchFirNode::new(taps, state)
 }
 
 #[cfg(test)]
@@ -389,7 +362,7 @@ mod test {
             Complex::zero(),
         ]);
 
-        let mut mynode = fir_node::batch_fir_node_with_state(
+        let mut mynode = fir_node::BatchFirNode::new(
             vec![
                 Complex::new(9, 0),
                 Complex::new(8, 7),
@@ -397,7 +370,7 @@ mod test {
                 Complex::new(4, 3),
                 Complex::new(2, 1),
             ],
-            vec![Complex::zero(); 5],
+            Some(vec![Complex::zero(); 5]),
         );
 
         #[derive(Node)]

--- a/src/hardware/radio.rs
+++ b/src/hardware/radio.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use std::default::Default;
 
 /// A trait to capture the ability to send samples out of the hardware
 /// platform on a particular output.
@@ -31,6 +32,14 @@ where
     T: RadioTx<U>,
     U: Clone,
 {
+    pub fn new(radio: T, output_idx: usize) -> Self {
+        RadioTxNode {
+            radio,
+            output_idx,
+            input: Default::default(),
+        }
+    }
+
     pub fn run(&mut self, samples: &[U]) -> Result<(), NodeError> {
         self.radio.send_samples(samples, self.output_idx);
         Ok(())
@@ -56,6 +65,15 @@ where
     T: RadioRx<U>,
     U: Clone,
 {
+    pub fn new(radio: T, input_idx: usize, num_samples: usize) -> Self {
+        RadioRxNode {
+            radio,
+            input_idx,
+            num_samples,
+            sender: Default::default(),
+        }
+    }
+
     pub fn run(&mut self) -> Result<Vec<U>, NodeError> {
         Ok(self.radio.recv_samples(self.num_samples, self.input_idx))
     }

--- a/src/hardware/rtlsdr_radio.rs
+++ b/src/hardware/rtlsdr_radio.rs
@@ -86,6 +86,13 @@ mod test {
         }
 
         impl CheckNode {
+            pub fn new(num_samples: usize) -> Self {
+                CheckNode {
+                    num_samples,
+                    recv: Default::default(),
+                }
+            }
+
             pub fn run(&mut self, samples: &[u8]) -> Result<(), NodeError> {
                 assert_eq!(samples.len(), self.num_samples);
                 Ok(())

--- a/src/io/raw_iq.rs
+++ b/src/io/raw_iq.rs
@@ -31,7 +31,7 @@ impl<R: Read> IQInput<R> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no-run
     /// use std::fs::File;
     /// use std::io::BufReader;
     /// use comms_rs::io::raw_iq::IQInput;
@@ -92,7 +92,7 @@ impl<R: Read> IQBatchInput<R> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no-run
     /// use std::fs::File;
     /// use comms_rs::io::raw_iq::IQBatchInput;
     ///
@@ -154,7 +154,7 @@ impl<W: Write> IQOutput<W> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no-run
     /// use std::fs::File;
     /// use std::io::BufWriter;
     /// use comms_rs::io::raw_iq::IQOutput;
@@ -195,7 +195,7 @@ impl<W: Write> IQBatchOutput<W> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```no-run
     /// use std::fs::File;
     /// use comms_rs::io::raw_iq::IQBatchOutput;
     ///

--- a/src/modulation/analog_node.rs
+++ b/src/modulation/analog_node.rs
@@ -4,7 +4,7 @@ use num::Complex;
 use num::Float;
 use num::Zero;
 
-#[derive(Node)]
+#[derive(Node, Default)]
 #[pass_by_ref]
 pub struct FMDemodNode<T>
 where
@@ -19,14 +19,15 @@ impl<T> FMDemodNode<T>
 where
     T: Float + Zero,
 {
+    pub fn new() -> Self {
+        FMDemodNode {
+            fm: analog::FM::new(),
+            input: Default::default(),
+            sender: Default::default(),
+        }
+    }
+
     pub fn run(&mut self, samples: &[Complex<T>]) -> Result<Vec<T>, NodeError> {
         Ok(self.fm.demod(samples))
     }
-}
-
-pub fn fm_demod_node<T>() -> FMDemodNode<T>
-where
-    T: Float + Zero,
-{
-    FMDemodNode::new(analog::FM::new())
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -18,6 +18,12 @@
 //! }
 //!
 //! impl Node1 {
+//!     pub fn new() -> Self {
+//!         Node1 {
+//!             sender: Default::default(),
+//!         }
+//!     }
+//!
 //!     pub fn run(&mut self) -> Result<u32, NodeError> {
 //!         Ok(1)
 //!     }
@@ -29,6 +35,12 @@
 //! }
 //!
 //! impl Node2 {
+//!     pub fn new() -> Self {
+//!         Node2 {
+//!             input: Default::default(),
+//!         }
+//!     }
+//!
 //!     pub fn run(&mut self, x: u32) -> Result<(), NodeError> {
 //!         assert_eq!(x, 1);
 //!         Ok(())
@@ -96,6 +108,12 @@ pub trait Node {
 /// # }
 /// #
 /// # impl Node1 {
+/// #   pub fn new() -> Self {
+/// #       Node1 {
+/// #           sender: Default::default(),
+/// #       }
+/// #   }
+/// #
 /// #   pub fn run(&mut self) -> Result<u32, NodeError> {
 /// #       Ok(1)
 /// #   }
@@ -107,6 +125,12 @@ pub trait Node {
 /// # }
 /// #
 /// # impl Node2 {
+/// #   pub fn new() -> Self {
+/// #       Node2 {
+/// #           recv: Default::default(),
+/// #       }
+/// #   }
+/// #
 /// #   pub fn run(&mut self, x: u32) -> Result<(), NodeError> {
 /// #       assert_eq!(x, 1);
 /// #       Ok(())
@@ -145,6 +169,12 @@ macro_rules! connect_nodes {
 /// # }
 /// #
 /// # impl Node1 {
+/// #   pub fn new() -> Self {
+/// #       Node1 {
+/// #           sender: Default::default(),
+/// #       }
+/// #   }
+/// #
 /// #   pub fn run(&mut self) -> Result<u32, NodeError> {
 /// #       Ok(1)
 /// #   }
@@ -156,6 +186,12 @@ macro_rules! connect_nodes {
 /// # }
 /// #
 /// # impl Node2 {
+/// #   pub fn new() -> Self {
+/// #       Node2 {
+/// #           recv: Default::default(),
+/// #       }
+/// #   }
+/// #
 /// #   pub fn run(&mut self, x: u32) -> Result<(), NodeError> {
 /// #       assert_eq!(x, 1);
 /// #       Ok(())
@@ -197,6 +233,12 @@ macro_rules! connect_nodes_feedback {
 /// # }
 ///
 /// # impl Node1 {
+/// #     pub fn new() -> Self {
+/// #         Node1 {
+/// #             sender: Default::default(),
+/// #         }
+/// #     }
+/// #
 /// #     pub fn run(&mut self) -> Result<u32, NodeError> {
 /// #         Ok(1)
 /// #     }
@@ -208,6 +250,12 @@ macro_rules! connect_nodes_feedback {
 /// # }
 ///
 /// # impl Node2 {
+/// #     pub fn new() -> Self {
+/// #         Node2 {
+/// #             input: Default::default(),
+/// #         }
+/// #     }
+/// #
 /// #     pub fn run(&mut self, x: u32) -> Result<(), NodeError> {
 /// #         assert_eq!(x, 1);
 /// #         Ok(())
@@ -252,6 +300,12 @@ macro_rules! start_nodes {
 /// # }
 ///
 /// # impl Node1 {
+/// #     pub fn new() -> Self {
+/// #         Node1 {
+/// #             sender: Default::default(),
+/// #         }
+/// #     }
+/// #
 /// #     pub fn run(&mut self) -> Result<u32, NodeError> {
 /// #         Ok(1)
 /// #     }
@@ -263,6 +317,12 @@ macro_rules! start_nodes {
 /// # }
 ///
 /// # impl Node2 {
+/// #     pub fn new() -> Self {
+/// #         Node2 {
+/// #             input: Default::default(),
+/// #         }
+/// #     }
+/// #
 /// #     pub fn run(&mut self, x: u32) -> Result<(), NodeError> {
 /// #         assert_eq!(x, 1);
 /// #         Ok(())
@@ -307,6 +367,12 @@ mod test {
         }
 
         impl Node1 {
+            pub fn new() -> Self {
+                Node1 {
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(&mut self) -> Result<u32, NodeError> {
                 Ok(1)
             }
@@ -318,6 +384,12 @@ mod test {
         }
 
         impl Node2 {
+            pub fn new() -> Self {
+                Node2 {
+                    input: Default::default(),
+                }
+            }
+
             pub fn run(&mut self, x: u32) -> Result<(), NodeError> {
                 assert_eq!(x, 1);
                 Ok(())
@@ -357,6 +429,13 @@ mod test {
         }
 
         impl Node1 {
+            pub fn new() -> Self {
+                Node1 {
+                    agg: vec![],
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(&mut self) -> Result<Option<Arc<Vec<u32>>>, NodeError> {
                 if self.agg.len() < 2 {
                     self.agg.push(1);
@@ -377,6 +456,13 @@ mod test {
         }
 
         impl Node2 {
+            pub fn new() -> Self {
+                Node2 {
+                    input: Default::default(),
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(
                 &mut self,
                 input: &Arc<Vec<u32>>,
@@ -396,6 +482,12 @@ mod test {
         }
 
         impl Node3 {
+            pub fn new() -> Self {
+                Node3 {
+                    input: Default::default(),
+                }
+            }
+
             pub fn run(
                 &mut self,
                 input: &Arc<Vec<u32>>,
@@ -405,7 +497,7 @@ mod test {
             }
         }
 
-        let mut node1 = Node1::new(Vec::new());
+        let mut node1 = Node1::new();
         let mut node2 = Node2::new();
         let mut node3 = Node3::new();
 
@@ -436,6 +528,12 @@ mod test {
         }
 
         impl Node1 {
+            pub fn new() -> Self {
+                Node1 {
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(&mut self) -> Result<Arc<Vec<i16>>, NodeError> {
                 let mut random = vec![0i16; 10000];
                 thread_rng().fill(random.as_mut_slice());
@@ -451,6 +549,13 @@ mod test {
         }
 
         impl Node2 {
+            pub fn new() -> Self {
+                Node2 {
+                    input: Default::default(),
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(
                 &mut self,
                 x: &Arc<Vec<i16>>,
@@ -471,6 +576,13 @@ mod test {
         }
 
         impl Node3 {
+            pub fn new() -> Self {
+                Node3 {
+                    count: 0,
+                    input: Default::default(),
+                }
+            }
+
             pub fn run(
                 &mut self,
                 _val: &Arc<Vec<i16>>,
@@ -487,7 +599,7 @@ mod test {
 
         let mut node1 = Node1::new();
         let mut node2 = Node2::new();
-        let mut node3 = Node3::new(0);
+        let mut node3 = Node3::new();
 
         connect_nodes!(node1, sender, node2, input);
         connect_nodes!(node2, sender, node3, input);
@@ -507,6 +619,12 @@ mod test {
         }
 
         impl Node1 {
+            pub fn new() -> Self {
+                Node1 {
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(&mut self) -> Result<Arc<Vec<i16>>, NodeError> {
                 let mut random = vec![0i16; 10000];
                 thread_rng().fill(random.as_mut_slice());
@@ -522,6 +640,13 @@ mod test {
         }
 
         impl Node2 {
+            pub fn new() -> Self {
+                Node2 {
+                    input: Default::default(),
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(
                 &mut self,
                 x: &Arc<Vec<i16>>,
@@ -542,6 +667,13 @@ mod test {
         }
 
         impl Node3 {
+            pub fn new() -> Self {
+                Node3 {
+                    count: 0,
+                    input: Default::default(),
+                }
+            }
+
             pub fn run(
                 &mut self,
                 _val: &Arc<Vec<i16>>,
@@ -558,7 +690,7 @@ mod test {
 
         let mut node1 = Node1::new();
         let mut node2 = Node2::new();
-        let mut node3 = Node3::new(0);
+        let mut node3 = Node3::new();
 
         connect_nodes!(node1, sender, node2, input);
         connect_nodes!(node2, sender, node3, input);
@@ -583,6 +715,12 @@ mod test {
         }
 
         impl NoInputNode {
+            pub fn new() -> Self {
+                NoInputNode {
+                    output: Default::default(),
+                }
+            }
+
             pub fn run(&mut self) -> Result<u32, NodeError> {
                 Ok(1)
             }
@@ -594,6 +732,12 @@ mod test {
         }
 
         impl AnotherNode {
+            pub fn new() -> Self {
+                AnotherNode {
+                    output: Default::default(),
+                }
+            }
+
             pub fn run(&mut self) -> Result<f64, NodeError> {
                 Ok(2.0)
             }
@@ -609,6 +753,14 @@ mod test {
         }
 
         impl DoubleInputNode {
+            pub fn new() -> Self {
+                DoubleInputNode {
+                    recv1: Default::default(),
+                    recv2: Default::default(),
+                    output: Default::default(),
+                }
+            }
+
             pub fn run(&mut self, x: u32, y: f64) -> Result<f32, NodeError> {
                 Ok((f64::from(x) + y) as f32)
             }
@@ -620,6 +772,12 @@ mod test {
         }
 
         impl CheckNode {
+            pub fn new() -> Self {
+                CheckNode {
+                    recv: Default::default(),
+                }
+            }
+
             pub fn run(&mut self, x: f32) -> Result<(), NodeError> {
                 assert!(x - 3.0f32 < std::f32::EPSILON, "Fan-out failed.");
                 Ok(())
@@ -665,6 +823,13 @@ mod test {
         }
 
         impl OneNode {
+            pub fn new() -> Self {
+                OneNode {
+                    count: 0,
+                    output: Default::default(),
+                }
+            }
+
             pub fn run(&mut self) -> Result<i32, NodeError> {
                 self.count += 1;
                 Ok(self.count)
@@ -679,14 +844,22 @@ mod test {
         }
 
         impl CounterNode {
+            pub fn new() -> Self {
+                CounterNode {
+                    count: 0,
+                    recv: Default::default(),
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(&mut self, val: i32) -> Result<i32, NodeError> {
                 self.count += val;
                 Ok(self.count)
             }
         }
 
-        let mut one_node = OneNode::new(0);
-        let mut count_node = CounterNode::new(0);
+        let mut one_node = OneNode::new();
+        let mut count_node = CounterNode::new();
         connect_nodes!(one_node, output, count_node, recv);
 
         thread::spawn(move || {
@@ -716,6 +889,14 @@ mod test {
         }
 
         impl AddNode {
+            pub fn new() -> Self {
+                AddNode {
+                    count: 1,
+                    recv: Default::default(),
+                    sender: Default::default(),
+                }
+            }
+
             pub fn run(&mut self, val: i32) -> Result<i32, NodeError> {
                 self.count += val;
                 Ok(self.count)
@@ -730,14 +911,22 @@ mod test {
         }
 
         impl PrintNode {
+            pub fn new() -> Self {
+                PrintNode {
+                    count: 0,
+                    recv: Default::default(),
+                    output: Default::default(),
+                }
+            }
+
             pub fn run(&mut self, val: i32) -> Result<i32, NodeError> {
                 self.count = val;
                 Ok(val)
             }
         }
 
-        let mut add_node = AddNode::new(1);
-        let mut print_node = PrintNode::new(0);
+        let mut add_node = AddNode::new();
+        let mut print_node = PrintNode::new();
         connect_nodes!(add_node, sender, print_node, recv);
         connect_nodes_feedback!(print_node, output, add_node, recv, 0);
         start_nodes!(add_node);

--- a/src/util/resample_node.rs
+++ b/src/util/resample_node.rs
@@ -19,6 +19,14 @@ impl<T> DecimateNode<T>
 where
     T: Copy,
 {
+    pub fn new(dec_rate: usize) -> Self {
+        DecimateNode {
+            dec_rate,
+            input: Default::default(),
+            sender: Default::default(),
+        }
+    }
+
     pub fn run(&mut self, signal: &[T]) -> Result<Vec<T>, NodeError> {
         Ok(self.decimate(signal))
     }

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -11,6 +11,12 @@ pub struct Node1 {
 }
 
 impl Node1 {
+    fn new() -> Self {
+        Node1 {
+            sender: Default::default(),
+        }
+    }
+
     fn run(&mut self) -> Result<u32, NodeError> {
         Ok(1)
     }
@@ -24,6 +30,14 @@ pub struct Node2 {
 }
 
 impl Node2 {
+    fn new(stuff: u32) -> Self {
+        Node2 {
+            stuff,
+            recv_input: Default::default(),
+            sender: Default::default(),
+        }
+    }
+
     fn run(&mut self, x: u32) -> Result<u32, NodeError> {
         assert_eq!(x, 1);
         Ok(x + self.stuff)
@@ -36,6 +50,12 @@ pub struct Node3 {
 }
 
 impl Node3 {
+    fn new() -> Self {
+        Node3 {
+            recv_input: Default::default(),
+        }
+    }
+
     fn run(&mut self, x: u32) -> Result<(), NodeError> {
         assert_eq!(x, 6);
         Ok(())

--- a/tests/node_test.rs
+++ b/tests/node_test.rs
@@ -13,6 +13,12 @@ fn simple_nodes() {
     }
 
     impl SourceNode {
+        pub fn new() -> Self {
+            SourceNode {
+                sender: Default::default(),
+            }
+        }
+
         pub fn run(&mut self) -> Result<u32, NodeError> {
             Ok(1)
         }
@@ -24,6 +30,12 @@ fn simple_nodes() {
     }
 
     impl SinkNode {
+        pub fn new() -> Self {
+            SinkNode {
+                input: Default::default(),
+            }
+        }
+
         pub fn run(&mut self, input: u32) -> Result<(), NodeError> {
             assert_eq!(input, 1);
             Ok(())


### PR DESCRIPTION
For a more consistent experience, `#[derive(Node)]` no longer implements `new()` automatically. This puts the onus on the node author, but this allows for documentation of `new()` and significantly more flexibility in node constructors.

* Implemented `new()` for each node. Many functions that were helper functions for creating nodes have been moved into the `new()` functions for the nodes.
* Updated all of the unit tests and documentation.