### PR TITLE
Adding BPSK Modulation Example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,15 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,7 +150,6 @@ name = "comms-rs"
 version = "0.1.0"
 dependencies = [
  "assert_approx_eq 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -173,6 +163,7 @@ dependencies = [
  "rtlsdr 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustfft 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -345,6 +336,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "glob"
 version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "half"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -835,6 +831,16 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde_cbor"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "slice-deque"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,7 +1021,6 @@ dependencies = [
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum assert_approx_eq 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a38a0dd5749f34b8a61d7c1cc47e68c7955676bd17e1b25dd1d30901c556655"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
-"checksum bincode 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f2fb9e29e72fd6bc12071533d5dc7664cb01480c59406f656d7ac25c7bd8ff7"
 "checksum bindgen 0.32.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8b242e11a8f446f5fc7b76b37e81d737cabca562a927bd33766dac55b5f1177f"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
@@ -1046,6 +1051,7 @@ dependencies = [
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9353c2a89d550b58fa0061d8ed8d002a7d8cdf2494eb0e432859bd3a9e543836"
 "checksum hound 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a164bb2ceaeff4f42542bdb847c41517c78a60f5649671b2a07312b6e117549"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
@@ -1104,6 +1110,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
+"checksum serde_cbor 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45cd6d95391b16cd57e88b68be41d504183b7faae22030c0cc3b3f73dd57b2fd"
 "checksum slice-deque 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "bf9114aa87a7c0ce55425e175d553fa0bef683c7bb2add185a878a2ff8643529"
 "checksum smallvec 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "153ffa32fd170e9944f7e0838edf824a754ec4c1fc64746fcc9fe1f8fa602e5d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rodio = {version = "0.8", optional = true}
 rustfft = "2.1"
 rtlsdr = {version = "0.1", optional = true}
 serde = "1"
-bincode = "1"
+serde_cbor = "0.9"
 zmq = {version = "0.8", optional = true}
 node_derive = {path = "node_derive"}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,7 @@ required-features = ["rtlsdr_node", "audio_node"]
 [[example]]
 name = "play_audio"
 required-features = ["audio_node"]
+
+[[example]]
+name = "bpsk_mod"
+required-features = ["zmq_node"]

--- a/examples/bpsk_mod.rs
+++ b/examples/bpsk_mod.rs
@@ -11,7 +11,8 @@ use comms_rs::util::rand_node;
 use num::{Complex, Num, NumCast, Zero};
 use std::io::BufWriter;
 use std::fs::File;
-use std::time::Instant;
+use std::thread;
+use std::time::Duration;
 
 /// An example that will generate random numbers, pass them through a BPSK
 /// modulation and a pulse shaper, then broadcast them out to a file and 
@@ -187,10 +188,5 @@ fn main() {
         deinterleave
     );
 
-    let start = Instant::now();
-    loop {
-        if start.elapsed().as_secs() > 10 {
-            break;
-        }
-    }
+    thread::sleep(Duration::from_secs(10));
 }

--- a/examples/bpsk_mod.rs
+++ b/examples/bpsk_mod.rs
@@ -1,0 +1,185 @@
+#[macro_use]
+extern crate comms_rs;
+extern crate zmq;
+
+use comms_rs::filter::fir_node::BatchFirNode;
+use comms_rs::io::raw_iq::IQBatchOutput;
+use comms_rs::io::zmq_node::ZMQSend;
+use comms_rs::prelude::*;
+use comms_rs::util::math;
+use comms_rs::util::rand_node;
+use num::{Complex, Num, NumCast, Zero};
+use std::fs::File;
+use std::time::Instant;
+
+fn main() {
+    #[derive(Node, Default)]
+    #[aggregate]
+    struct BpskMod {
+        input: NodeReceiver<u8>,
+        num_samples: usize,
+        state: Vec<Complex<f32>>,
+        output: NodeSender<Vec<Complex<f32>>>,
+    }
+
+    impl BpskMod {
+        pub fn new(num_samples: usize) -> Self {
+            BpskMod {
+                num_samples,
+                state: vec![],
+                ..Default::default()
+            }
+        }
+
+        pub fn run(
+            &mut self,
+            input: u8,
+        ) -> Result<Option<Vec<Complex<f32>>>, NodeError> {
+            self.state.push(Complex::new(input as f32 * 2.0 - 1.0, 0.0));
+            if self.state.len() == self.num_samples {
+                let state_cl = self.state.clone();
+                self.state = vec![];
+                Ok(Some(state_cl))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    #[derive(Node)]
+    struct UpsampleNode<T>
+    where
+        T: Zero + Clone,
+    {
+        input: NodeReceiver<Vec<T>>,
+        upsample_factor: usize,
+        output: NodeSender<Vec<T>>,
+    }
+
+    impl<T> UpsampleNode<T>
+    where
+        T: Zero + Clone,
+    {
+        pub fn new(upsample_factor: usize) -> Self {
+            UpsampleNode {
+                upsample_factor,
+                input: Default::default(),
+                output: Default::default(),
+            }
+        }
+
+        pub fn run(&mut self, input: Vec<T>) -> Result<Vec<T>, NodeError> {
+            let mut out = vec![T::zero(); input.len() * self.upsample_factor];
+            let mut ix = 0;
+            for val in input {
+                out[ix] = val;
+                ix += self.upsample_factor;
+            }
+            Ok(out)
+        }
+    }
+
+    #[derive(Node)]
+    struct ConvertNode<T, U>
+    where
+        T: Clone + Num + NumCast,
+        U: Clone + Num + NumCast,
+    {
+        input: NodeReceiver<Vec<Complex<T>>>,
+        output: NodeSender<Vec<Complex<U>>>,
+    }
+
+    impl<T, U> ConvertNode<T, U>
+    where
+        T: Clone + Num + NumCast,
+        U: Clone + Num + NumCast,
+    {
+        pub fn new() -> Self {
+            ConvertNode {
+                input: Default::default(),
+                output: Default::default(),
+            }
+        }
+
+        pub fn run(
+            &mut self,
+            input: Vec<Complex<T>>,
+        ) -> Result<Vec<Complex<U>>, NodeError> {
+            let out: Vec<Complex<U>> = input
+                .iter()
+                .map(|x| math::cast_complex(x).unwrap())
+                .collect();
+            Ok(out)
+        }
+    }
+
+    #[derive(Node)]
+    struct DeinterleaveNode<T>
+    where
+        T: Clone + Num + NumCast,
+    {
+        input: NodeReceiver<Vec<Complex<T>>>,
+        output: NodeSender<Vec<T>>,
+    }
+
+    impl<T> DeinterleaveNode<T>
+    where
+        T: Clone + Num + NumCast,
+    {
+        pub fn new() -> Self {
+            DeinterleaveNode {
+                input: Default::default(),
+                output: Default::default(),
+            }
+        }
+
+        pub fn run(
+            &mut self,
+            input: Vec<Complex<T>>,
+        ) -> Result<Vec<T>, NodeError> {
+            let out: Vec<T> = input
+                .iter()
+                .flat_map(|x| vec![x.re.clone(), x.im.clone()])
+                .collect();
+            Ok(out)
+        }
+    }
+
+    let mut rand_bits = rand_node::random_bit();
+    let mut bpsk_node = BpskMod::new(128);
+    let mut upsample = UpsampleNode::new(4);
+    let sam_per_sym = 4.0;
+    let taps: Vec<Complex<f32>> =
+        math::rrc_taps(32, sam_per_sym, 0.25).unwrap();
+    let mut pulse_shape = BatchFirNode::new(taps, None);
+    let writer = File::create("/tmp/bpsk_out.bin").unwrap();
+    let mut convert = ConvertNode::new();
+    let mut iq_out = IQBatchOutput::new(writer);
+    let mut zmq = ZMQSend::new("tcp://*:5563", zmq::SocketType::PUB, 0);
+    let mut deinterleave = DeinterleaveNode::new();
+
+    connect_nodes!(rand_bits, sender, bpsk_node, input);
+    connect_nodes!(bpsk_node, output, upsample, input);
+    connect_nodes!(upsample, output, pulse_shape, input);
+    connect_nodes!(pulse_shape, sender, convert, input);
+    connect_nodes!(convert, output, iq_out, input);
+    connect_nodes!(convert, output, deinterleave, input);
+    connect_nodes!(deinterleave, output, zmq, input);
+    start_nodes!(
+        rand_bits,
+        bpsk_node,
+        upsample,
+        pulse_shape,
+        convert,
+        iq_out,
+        deinterleave,
+        zmq
+    );
+
+    let start = Instant::now();
+    loop {
+        if start.elapsed().as_secs() > 10 {
+            break;
+        }
+    }
+}

--- a/examples/bpsk_mod.rs
+++ b/examples/bpsk_mod.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate comms_rs;
 
-use zmq;
 use comms_rs::filter::fir_node::BatchFirNode;
 use comms_rs::io::raw_iq::IQBatchOutput;
 use comms_rs::io::zmq_node::ZMQSend;
@@ -9,13 +8,14 @@ use comms_rs::prelude::*;
 use comms_rs::util::math;
 use comms_rs::util::rand_node;
 use num::{Complex, Num, NumCast, Zero};
-use std::io::BufWriter;
 use std::fs::File;
+use std::io::BufWriter;
 use std::thread;
 use std::time::Duration;
+use zmq;
 
 /// An example that will generate random numbers, pass them through a BPSK
-/// modulation and a pulse shaper, then broadcast them out to a file and 
+/// modulation and a pulse shaper, then broadcast them out to a file and
 /// via ZeroMQ for visualization.
 fn main() {
     // A simple node to perform BPSK modulation. Only broadcasts a message
@@ -88,7 +88,7 @@ fn main() {
         }
     }
 
-    // A generic node to convert from one complex type to another. 
+    // A generic node to convert from one complex type to another.
     #[derive(Node)]
     struct ConvertNode<T, U>
     where
@@ -149,10 +149,8 @@ fn main() {
             &mut self,
             input: Vec<Complex<T>>,
         ) -> Result<Vec<T>, NodeError> {
-            let out: Vec<T> = input
-                .iter()
-                .flat_map(|x| vec![x.re, x.im])
-                .collect();
+            let out: Vec<T> =
+                input.iter().flat_map(|x| vec![x.re, x.im]).collect();
             Ok(out)
         }
     }

--- a/src/fft/fft_node.rs
+++ b/src/fft/fft_node.rs
@@ -27,7 +27,7 @@ use std::default::Default;
 #[pass_by_ref]
 pub struct FFTBatchNode<T>
 where
-    T: NumCast + Clone + Num,
+    T: NumCast + Copy + Num,
 {
     pub input: NodeReceiver<Vec<Complex<T>>>,
     batch_fft: BatchFFT,
@@ -36,7 +36,7 @@ where
 
 impl<T> FFTBatchNode<T>
 where
-    T: NumCast + Clone + Num,
+    T: NumCast + Copy + Num,
 {
     /// Constructs a node that performs FFT or IFFTs in batches.
     ///
@@ -103,7 +103,7 @@ where
 #[pass_by_ref]
 pub struct FFTSampleNode<T>
 where
-    T: NumCast + Clone + Num,
+    T: NumCast + Copy + Num,
 {
     pub input: NodeReceiver<Complex<T>>,
     sample_fft: SampleFFT<T>,
@@ -112,7 +112,7 @@ where
 
 impl<T> FFTSampleNode<T>
 where
-    T: NumCast + Clone + Num,
+    T: NumCast + Copy + Num,
 {
     /// Constructs a node that performs FFT or IFFTs, receiving a sample at a time
     /// versus a batch of samples.
@@ -156,7 +156,7 @@ where
         &mut self,
         sample: &Complex<T>,
     ) -> Result<Option<Vec<Complex<T>>>, NodeError> {
-        self.sample_fft.samples.push(sample.clone());
+        self.sample_fft.samples.push(*sample);
         if self.sample_fft.samples.len() == self.sample_fft.fft_size {
             let results = self.sample_fft.run_fft();
             self.sample_fft.samples = vec![];

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -72,7 +72,7 @@ impl BatchFFT {
     /// ```
     pub fn run_fft<T>(&mut self, data: &[Complex<T>]) -> Vec<Complex<T>>
     where
-        T: NumCast + Clone + Num,
+        T: NumCast + Copy + Num,
     {
         // Convert the input type from interleaved values to Complex<f32>.
         let mut input: Vec<FFTComplex<f64>> = data
@@ -111,7 +111,7 @@ pub struct SampleFFT<T> {
 
 impl<T> SampleFFT<T>
 where
-    T: NumCast + Clone + Num,
+    T: NumCast + Copy + Num,
 {
     /// Creates a new `SampleFFT`.
     ///

--- a/src/io/zmq_node.rs
+++ b/src/io/zmq_node.rs
@@ -1,8 +1,9 @@
 use crate::io::zmq;
 use crate::prelude::*;
-use bincode::{deserialize, serialize};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde_cbor::de::from_slice;
+use serde_cbor::ser::to_vec_packed;
 
 /// A node that will send serialized data out of a ZMQ socket.
 #[derive(Node)]
@@ -58,7 +59,7 @@ where
     }
 
     pub fn send(&mut self, data: &T) -> Result<(), NodeError> {
-        let buffer: Vec<u8> = match serialize(&data) {
+        let buffer: Vec<u8> = match to_vec_packed(&data) {
             Ok(b) => b,
             Err(_) => return Err(NodeError::DataError),
         };
@@ -131,7 +132,7 @@ where
             Ok(b) => b,
             Err(_) => return Err(NodeError::CommError),
         };
-        let res: T = match deserialize(&bytes) {
+        let res: T = match from_slice(&bytes) {
             Ok(r) => r,
             Err(_) => return Err(NodeError::DataError),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 
 #![allow(clippy::unreadable_literal)]
 
-extern crate bincode;
 extern crate byteorder;
 extern crate crossbeam;
 extern crate crossbeam_channel;
@@ -28,6 +27,7 @@ extern crate rand;
 extern crate rayon;
 extern crate rustfft;
 extern crate serde;
+extern crate serde_cbor;
 
 #[macro_use]
 pub mod node;

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -74,7 +74,7 @@ impl Mixer {
     /// ```
     pub fn mix<T>(&mut self, input: &Complex<T>) -> Complex<T>
     where
-        T: NumCast + Clone + Num,
+        T: NumCast + Copy + Num,
     {
         let inp: Complex<f64> = math::cast_complex(input).unwrap();
         let res = inp * Complex::exp(&Complex::new(0.0, self.phase));
@@ -94,7 +94,7 @@ impl Mixer {
 #[pass_by_ref]
 pub struct MixerNode<T>
 where
-    T: Clone + Num + NumCast,
+    T: Copy + Num + NumCast,
 {
     pub input: NodeReceiver<Complex<T>>,
     mixer: Mixer,
@@ -103,7 +103,7 @@ where
 
 impl<T> MixerNode<T>
 where
-    T: Clone + Num + NumCast,
+    T: Copy + Num + NumCast,
 {
     /// Constructs a new `MixerNode<T>` with specified initial phase.
     ///

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -17,11 +17,11 @@ use std::f64::consts::PI;
 /// ```
 pub fn cast_complex<T, U>(input: &Complex<T>) -> Option<Complex<U>>
 where
-    T: Clone + Num + num_traits::NumCast,
-    U: Clone + Num + num_traits::NumCast,
+    T: Copy + Num + num_traits::NumCast,
+    U: Copy + Num + num_traits::NumCast,
 {
-    let re = U::from(input.re.clone())?;
-    let im = U::from(input.im.clone())?;
+    let re = U::from(input.re)?;
+    let im = U::from(input.im)?;
     Some(Complex::new(re, im))
 }
 
@@ -45,7 +45,7 @@ where
 /// ```
 pub fn rect_taps<T>(n_taps: usize) -> Option<Vec<Complex<T>>>
 where
-    T: Clone + Num + num_traits::NumCast,
+    T: Copy + Num + num_traits::NumCast,
 {
     let re = T::from(1)?;
     let im = T::from(0)?;
@@ -80,7 +80,7 @@ pub fn gaussian_taps<T>(
     alpha: f64,
 ) -> Option<Vec<Complex<T>>>
 where
-    T: Clone + Num + num_traits::NumCast,
+    T: Copy + Num + num_traits::NumCast,
 {
     let tsym = 1.0_f64;
     let fs = sam_per_sym / tsym;
@@ -151,7 +151,7 @@ pub fn rc_taps<T>(
     beta: f64,
 ) -> Option<Vec<Complex<T>>>
 where
-    T: Clone + Num + num_traits::NumCast,
+    T: Copy + Num + num_traits::NumCast,
 {
     let tsym = 1.0_f64;
     let fs = sam_per_sym / tsym;
@@ -216,7 +216,7 @@ pub fn rrc_taps<T>(
     beta: f64,
 ) -> Option<Vec<Complex<T>>>
 where
-    T: Clone + Num + num_traits::NumCast,
+    T: Copy + Num + num_traits::NumCast,
 {
     let tsym = 1.0_f64;
     let fs = sam_per_sym / tsym;

--- a/src/util/rand_node.rs
+++ b/src/util/rand_node.rs
@@ -25,7 +25,7 @@ use crate::prelude::*;
 #[derive(Node)]
 pub struct UniformNode<T>
 where
-    T: SampleUniform + Clone,
+    T: SampleUniform + Copy,
 {
     rng: StdRng,
     dist: Uniform<T>,
@@ -34,7 +34,7 @@ where
 
 impl<T> UniformNode<T>
 where
-    T: SampleUniform + Clone,
+    T: SampleUniform + Copy,
 {
     /// Builds a closure for generating random numbers with a Uniform distribution.
     ///


### PR DESCRIPTION
Creating an example that demonstrates BPSK modulation and pulse shaping and broadcasts out to a file and ZeroMQ for visualization. This also includes a minor performance optimization where trait bounds that previously required Clone now require Copy for math operations as copies are going to be faster for numbers.