### PR TITLE
Removing ZeroMQ dependency from bpsk_mod

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,3 @@ required-features = ["audio_node"]
 
 [[example]]
 name = "bpsk_mod"
-required-features = ["zmq_node"]

--- a/node_derive/src/lib.rs
+++ b/node_derive/src/lib.rs
@@ -77,8 +77,8 @@ pub fn node_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     }
 
     let data = &input.data;
-    let mut recv_fields;
-    let mut send_fields;
+    let recv_fields;
+    let send_fields;
     match data {
         syn::Data::Struct(data_struct) => match &data_struct.fields {
             syn::Fields::Named(fields) => {

--- a/src/fft/mod.rs
+++ b/src/fft/mod.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 /// automatically cast any provided input appropriately, although it does
 /// expect the general form of `Complex<T>`.
 pub struct BatchFFT {
-    pub fft: Arc<FFT<f64>>,
+    pub fft: Arc<dyn FFT<f64>>,
     pub fft_size: usize,
 }
 
@@ -43,7 +43,7 @@ impl BatchFFT {
     /// let fft = planner.plan_fft(fft_size);
     /// let batch_fft = BatchFFT::new(fft, fft_size);
     /// ```
-    pub fn new(fft: Arc<FFT<f64>>, fft_size: usize) -> BatchFFT {
+    pub fn new(fft: Arc<dyn FFT<f64>>, fft_size: usize) -> BatchFFT {
         BatchFFT { fft, fft_size }
     }
 
@@ -104,7 +104,7 @@ impl BatchFFT {
 /// cast any provided input appropriately, although it does expect the general
 /// form of `Complex<T>`.
 pub struct SampleFFT<T> {
-    pub fft: Arc<FFT<f64>>,
+    pub fft: Arc<dyn FFT<f64>>,
     pub fft_size: usize,
     pub samples: Vec<Complex<T>>,
 }
@@ -133,7 +133,7 @@ where
     /// let fft = planner.plan_fft(fft_size);
     /// let sample_fft: SampleFFT<f64> = SampleFFT::new(fft, fft_size);
     /// ```
-    pub fn new(fft: Arc<FFT<f64>>, fft_size: usize) -> SampleFFT<T> {
+    pub fn new(fft: Arc<dyn FFT<f64>>, fft_size: usize) -> SampleFFT<T> {
         SampleFFT {
             fft,
             fft_size,

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -87,7 +87,7 @@ impl fmt::Display for NodeError {
 }
 
 impl error::Error for NodeError {
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         None
     }
 }


### PR DESCRIPTION
- So that we have an example that doesn't depend on any feature flags
  and so that we don't have any needless operations slowing performance,
  the ZeroMQ node was removed from bpsk_mod and the feature flag
  removed.
- Fixed warnings that arose from latest Rust update.