### PR TITLE
Feature/timing estimator

### DIFF
--- a/src/demodulation/mod.rs
+++ b/src/demodulation/mod.rs
@@ -1,2 +1,3 @@
 //! Nodes for demodulating signals.
 pub mod nco;
+pub mod timing_estimator;

--- a/src/demodulation/timing_estimator.rs
+++ b/src/demodulation/timing_estimator.rs
@@ -1,5 +1,6 @@
 use crate::filter::fir::batch_fir;
 use crate::util::math::qfilt_taps;
+use crate::util::MathError;
 use std::f64::consts::PI;
 
 extern crate num; // 0.2.0
@@ -41,7 +42,7 @@ impl TimingEstimator {
         n: u32,
         d: u32,
         alpha: f64,
-    ) -> Result<TimingEstimator, &'static str> {
+    ) -> Result<TimingEstimator, MathError> {
         // Generate Mengali's q(t)
         let taps = qfilt_taps(2 * n * d + 1, alpha, n)?;
         let taps = taps.iter().map(|x| Complex::new(*x as f64, 0.0)).collect();

--- a/src/demodulation/timing_estimator.rs
+++ b/src/demodulation/timing_estimator.rs
@@ -1,0 +1,109 @@
+use crate::prelude::*;
+use crate::filter::fir::batch_fir;
+use crate::util::math::qfilt_taps;
+use std::f64::consts::PI;
+
+extern crate num; // 0.2.0
+
+use num::complex::Complex;
+
+// Reference Chp. 8.4 in Mengali
+//
+pub struct TimingEstimator {
+    qfilt: Vec<Complex<f64>>,
+    delay: Vec<Complex<f64>>,
+    n: u32,
+    d: u32,
+}
+
+impl TimingEstimator {
+    /// Create a new TimingEstimator struct.
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - Samples per symbol of input signal.
+    /// * `d` - Delay of filters internal to the TimingEstimator in symbols.
+    ///         This effectively sets the pulse filter length to 2 * N * D in
+    ///         samples.
+    /// * `alpha` - Rolloff factor for internal filtering.  Should be on
+    ///             interval [0, 1].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use comms_rs::demodulation::timing_estimator::*;
+    ///
+    /// let n = 2;
+    /// let d = 5;
+    /// let alpha = 0.25;
+    /// let estimator = TimingEstimator::new(n, d, alpha);
+    /// ```
+    pub fn new(n: u32, d: u32, alpha: f64) -> Result<TimingEstimator, &'static str> {
+
+        // Generate Mengali's q(t)
+        let taps = qfilt_taps(2 * n * d, alpha, n, 1.0)?;
+        let taps = taps.iter().map(|x| Complex::new(*x as f64, 0.0)).collect();
+        let mut delay = vec![0.0; ((n * d) as i32 - 1) as usize];
+        delay.push(1.0);
+        let delay = delay.iter().map(|x| Complex::new(*x as f64, 0.0)).collect();
+
+        Ok(TimingEstimator {
+            qfilt: taps,
+            delay: delay,
+            n,
+            d,
+        })
+    }
+
+    /// Calculates a new timing estimate from the input sample vector.
+    ///
+    /// Result is in units normalized to the input vector sample rate.
+    ///
+    /// # Arguments
+    ///
+    /// * `samples` - Input vector of samples to calculate the timing
+    ///               estimate from.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use comms_rs::demodulation::timing_estimator::*;
+    /// use num::Complex;
+    ///
+    /// let n = 2;
+    /// let d = 5;
+    /// let alpha = 0.25;
+    /// let mut estimator = TimingEstimator::new(n, d, alpha).unwrap();
+    ///
+    /// let data = (0..100).map(|x| Complex::new(x as f64, 0.0)).collect();
+    ///
+    /// let estimate = estimator.push(&data);
+    /// ```
+    pub fn push(&mut self, samples: &Vec<Complex<f64>>) -> f64 {
+
+        let mut qin = vec![];
+        let mut din = vec![];
+        for (i, s) in samples.iter().enumerate() {
+
+            // Complex exponential for mixing
+            let r = Complex::new(0.0, -PI * i as f64 / self.n as f64).exp();
+
+            // Prepare inputs to parallel filters
+            qin.push(s.conj() * r);
+            din.push(s * r);
+        }
+
+        // Execute the parallel FIR filter
+        let mut initial_qfilt_state = vec![Complex::new(0.0, 0.0); (2 * self.n * self.d) as usize];
+        let mut initial_delay_state = vec![Complex::new(0.0, 0.0); (self.n * self.d) as usize];
+        let qout = batch_fir(&qin, &self.qfilt, &mut initial_qfilt_state);
+        let dout = batch_fir(&din, &self.delay, &mut initial_delay_state);
+
+        // Multiply input samples with mixing vector and delay by ND samples to
+        // ensure it lines up with qfilt output, then multiply by qfilt output
+        // and sum.
+        let sum_value: Complex<f64> = qout.iter().zip(dout.iter()).map(|(q, d)| q * d).sum();
+
+        -sum_value.arg() / (2.0 * PI)
+    }
+}

--- a/src/demodulation/timing_estimator.rs
+++ b/src/demodulation/timing_estimator.rs
@@ -1,4 +1,3 @@
-use crate::prelude::*;
 use crate::filter::fir::batch_fir;
 use crate::util::math::qfilt_taps;
 use std::f64::consts::PI;
@@ -23,8 +22,8 @@ impl TimingEstimator {
     ///
     /// * `n` - Samples per symbol of input signal.
     /// * `d` - Delay of filters internal to the TimingEstimator in symbols.
-    ///         This effectively sets the pulse filter length to 2 * N * D in
-    ///         samples.
+    ///         This effectively sets the pulse filter length to 2 * N * D + 1
+    ///         in samples.
     /// * `alpha` - Rolloff factor for internal filtering.  Should be on
     ///             interval [0, 1].
     ///
@@ -38,18 +37,22 @@ impl TimingEstimator {
     /// let alpha = 0.25;
     /// let estimator = TimingEstimator::new(n, d, alpha);
     /// ```
-    pub fn new(n: u32, d: u32, alpha: f64) -> Result<TimingEstimator, &'static str> {
-
+    pub fn new(
+        n: u32,
+        d: u32,
+        alpha: f64,
+    ) -> Result<TimingEstimator, &'static str> {
         // Generate Mengali's q(t)
-        let taps = qfilt_taps(2 * n * d, alpha, n, 1.0)?;
+        let taps = qfilt_taps(2 * n * d + 1, alpha, n)?;
         let taps = taps.iter().map(|x| Complex::new(*x as f64, 0.0)).collect();
-        let mut delay = vec![0.0; ((n * d) as i32 - 1) as usize];
+        let mut delay = vec![0.0; (n * d) as usize];
         delay.push(1.0);
-        let delay = delay.iter().map(|x| Complex::new(*x as f64, 0.0)).collect();
+        let delay =
+            delay.iter().map(|x| Complex::new(*x as f64, 0.0)).collect();
 
         Ok(TimingEstimator {
             qfilt: taps,
-            delay: delay,
+            delay,
             n,
             d,
         })
@@ -57,7 +60,7 @@ impl TimingEstimator {
 
     /// Calculates a new timing estimate from the input sample vector.
     ///
-    /// Result is in units normalized to the input vector sample rate.
+    /// Result is in samples.
     ///
     /// # Arguments
     ///
@@ -75,16 +78,14 @@ impl TimingEstimator {
     /// let alpha = 0.25;
     /// let mut estimator = TimingEstimator::new(n, d, alpha).unwrap();
     ///
-    /// let data = (0..100).map(|x| Complex::new(x as f64, 0.0)).collect();
+    /// let data: Vec<_> = (0..100).map(|x| Complex::new(x as f64, 0.0)).collect();
     ///
     /// let estimate = estimator.push(&data);
     /// ```
-    pub fn push(&mut self, samples: &Vec<Complex<f64>>) -> f64 {
-
+    pub fn push(&mut self, samples: &[Complex<f64>]) -> f64 {
         let mut qin = vec![];
         let mut din = vec![];
         for (i, s) in samples.iter().enumerate() {
-
             // Complex exponential for mixing
             let r = Complex::new(0.0, -PI * i as f64 / self.n as f64).exp();
 
@@ -94,17 +95,20 @@ impl TimingEstimator {
         }
 
         // Execute the parallel FIR filter
-        let mut initial_qfilt_state = vec![Complex::new(0.0, 0.0); (2 * self.n * self.d) as usize];
-        let mut initial_delay_state = vec![Complex::new(0.0, 0.0); (self.n * self.d) as usize];
+        let mut initial_qfilt_state =
+            vec![Complex::new(0.0, 0.0); (2 * self.n * self.d + 1) as usize];
+        let mut initial_delay_state =
+            vec![Complex::new(0.0, 0.0); (self.n * self.d + 1) as usize];
         let qout = batch_fir(&qin, &self.qfilt, &mut initial_qfilt_state);
         let dout = batch_fir(&din, &self.delay, &mut initial_delay_state);
 
         // Multiply input samples with mixing vector and delay by ND samples to
         // ensure it lines up with qfilt output, then multiply by qfilt output
         // and sum.
-        let sum_value: Complex<f64> = qout.iter().zip(dout.iter()).map(|(q, d)| q * d).sum();
+        let sum_value: Complex<f64> =
+            qout.iter().zip(dout.iter()).map(|(q, d)| q * d).sum();
 
-        -sum_value.arg() / (2.0 * PI)
+        -(self.n as f64) * sum_value.arg() / (2.0 * PI)
     }
 }
 
@@ -113,39 +117,47 @@ mod test {
     use crate::demodulation::timing_estimator::*;
     use crate::util::math::rrc_taps;
     use num::Complex;
-    use rand::prelude::*;
     use rand::distributions::Uniform;
+    use rand::prelude::*;
     use rand::rngs::SmallRng;
     use std::f64::consts::PI;
 
     #[test]
     fn test_timing_estimator() {
-        let truth = 0.0;
+        let alpha = 0.5;
+        let sam_per_sym = 10;
 
         // Generate QPSK signal
         let mut rng = SmallRng::seed_from_u64(0);
         let interval = Uniform::new(0, 4);
-        let data: Vec<_> = (0..100).map(|_| rng.sample(interval))
-                           .map(|x| Complex::new(0.0, 2.0 * PI * x as f64 / 4.0 + PI / 4.0).exp()).collect();
+        let data: Vec<_> = (0..1000)
+            .map(|_| rng.sample(interval))
+            .map(|x| {
+                Complex::new(0.0, 2.0 * PI * x as f64 / 4.0 + PI / 4.0).exp()
+            })
+            .collect();
 
         let mut symbols = vec![];
         for pt in data {
             symbols.push(pt);
-            symbols.push(Complex::new(0.0, 0.0));
+            for _ in 1..sam_per_sym {
+                symbols.push(Complex::new(0.0, 0.0));
+            }
         }
 
-        let rrctaps = rrc_taps(20, 2.0, 0.25).unwrap();
-        let mut state = vec![Complex::new(0.0, 0.0); 20];
+        let n_taps = sam_per_sym * 10 + 1;
+        let rrctaps = rrc_taps(n_taps, sam_per_sym as f64, alpha).unwrap();
+        let mut state = vec![Complex::new(0.0, 0.0); n_taps as usize];
         let samples = batch_fir(&symbols, &rrctaps, &mut state);
 
         // Create estimator
-        let n = 2;
+        let truth = 2;
+        let n = sam_per_sym;
         let d = 5;
-        let alpha = 0.25;
         let mut estimator = TimingEstimator::new(n, d, alpha).unwrap();
-        let estimate = estimator.push(&samples);
-
+        let estimate = estimator.push(&samples[truth..]);
         println!("{}", estimate);
-        assert!((truth - estimate).abs() < std::f64::EPSILON);
+
+        assert!((truth as f64 + estimate).abs() < 0.01);
     }
 }

--- a/src/demodulation/timing_estimator.rs
+++ b/src/demodulation/timing_estimator.rs
@@ -45,10 +45,8 @@ impl TimingEstimator {
         // Generate Mengali's q(t)
         let taps = qfilt_taps(2 * n * d + 1, alpha, n)?;
         let taps = taps.iter().map(|x| Complex::new(*x as f64, 0.0)).collect();
-        let mut delay = vec![0.0; (n * d) as usize];
-        delay.push(1.0);
-        let delay =
-            delay.iter().map(|x| Complex::new(*x as f64, 0.0)).collect();
+        let mut delay = vec![Complex::new(0.0, 0.0); (n * d) as usize];
+        delay.push(Complex::new(1.0, 0.0));
 
         Ok(TimingEstimator {
             qfilt: taps,

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -1,6 +1,8 @@
 use num::{Complex, Num};
 use std::f64::consts::PI;
 
+use crate::util::MathError;
+
 /// Casts a `Complex<T>` to a `Complex<U>`.
 ///
 /// All of the normal caveats with using the `as` keyword apply here for the
@@ -61,7 +63,7 @@ where
 ///
 /// * `n_taps` - Number of desired output taps
 /// * `sam_per_sym` - Samples per symbol
-/// * `beta` - Shaping parameter of the RC function
+/// * `alpha` - Shaping parameter of the function
 ///
 /// # Example
 ///
@@ -132,7 +134,8 @@ pub fn sinc(x: f64) -> f64 {
 ///
 /// * `n_taps` - Number of desired output taps
 /// * `sam_per_sym` - Samples per symbol
-/// * `beta` - Shaping parameter of the RC function
+/// * `beta` - Shaping parameter of the RC function.  Must be on the interval
+///            [0, 1].
 ///
 /// # Examples
 ///
@@ -149,10 +152,14 @@ pub fn rc_taps<T>(
     n_taps: u32,
     sam_per_sym: f64,
     beta: f64,
-) -> Option<Vec<Complex<T>>>
+) -> Result<Vec<Complex<T>>, MathError>
 where
     T: Copy + Num + num_traits::NumCast,
 {
+    if beta < 0.0 || beta > 1.0 {
+        return Err(MathError::InvalidRolloffError);
+    };
+
     let tsym = 1.0_f64;
     let fs = sam_per_sym / tsym;
 
@@ -173,19 +180,19 @@ where
     for i in 0..n_taps {
         let t = (f64::from(i) - f64::from(n_taps - 1) / 2.0) / fs;
 
-        let im = T::from(0)?;
+        let im = T::from(0).ok_or(MathError::ConvertError)?;
         if (t - zero_denom).abs() < std::f64::EPSILON
             || (t + zero_denom).abs() < std::f64::EPSILON
         {
-            let re = T::from(fint())?;
+            let re = T::from(fint()).ok_or(MathError::ConvertError)?;
             taps.push(Complex::new(re, im));
         } else {
-            let re = T::from(f(t))?;
+            let re = T::from(f(t)).ok_or(MathError::ConvertError)?;
             taps.push(Complex::new(re, im));
         }
     }
 
-    Some(taps)
+    Ok(taps)
 }
 
 /// Root Raised Cosine (RRC) filter tap calculator.
@@ -197,7 +204,8 @@ where
 ///
 /// * `n_taps` - Number of desired output taps
 /// * `sam_per_sym` - Samples per symbol
-/// * `beta` - Shaping parameter of the RRC function
+/// * `beta` - Shaping parameter of the RRC function.  Must be on the interval
+///            [0.0, 1.0].
 ///
 /// # Examples
 ///
@@ -214,10 +222,14 @@ pub fn rrc_taps<T>(
     n_taps: u32,
     sam_per_sym: f64,
     beta: f64,
-) -> Option<Vec<Complex<T>>>
+) -> Result<Vec<Complex<T>>, MathError>
 where
     T: Copy + Num + num_traits::NumCast,
 {
+    if beta < 0.0 || beta > 1.0 {
+        return Err(MathError::InvalidRolloffError);
+    };
+
     let tsym = 1.0_f64;
     let fs = sam_per_sym / tsym;
 
@@ -249,22 +261,22 @@ where
     for i in 0..n_taps {
         let t = (f64::from(i) - f64::from(n_taps - 1) / 2.0) / fs;
 
-        let im = T::from(0)?;
+        let im = T::from(0).ok_or(MathError::ConvertError)?;
         if t.abs() < std::f64::EPSILON {
-            let re = T::from(fzero())?;
+            let re = T::from(fzero()).ok_or(MathError::ConvertError)?;
             taps.push(Complex::new(re, im));
         } else if (t - zero_denom).abs() < std::f64::EPSILON
             || (t + zero_denom).abs() < std::f64::EPSILON
         {
-            let re = T::from(fint())?;
+            let re = T::from(fint()).ok_or(MathError::ConvertError)?;
             taps.push(Complex::new(re, im));
         } else {
-            let re = T::from(f(t))?;
+            let re = T::from(f(t)).ok_or(MathError::ConvertError)?;
             taps.push(Complex::new(re, im));
         }
     }
 
-    Some(taps)
+    Ok(taps)
 }
 
 /// Implementation of the Mengali qfilter tap calculator.
@@ -277,7 +289,8 @@ where
 /// * `n_taps` - Number of desired output taps.  Only takes odd numbers.  Even
 ///              numbers will be incremented by one and that shall be used
 ///              intead.
-/// * `alpha` - Shaping parameter of the function
+/// * `alpha` - Shaping parameter of the function. Must be on the interval
+///             [0.0, 1.0].
 /// * `sam_per_sym` - Samples per symbol
 ///
 /// # Examples
@@ -295,11 +308,9 @@ pub fn qfilt_taps(
     n_taps: u32,
     alpha: f64,
     sam_per_sym: u32,
-) -> Result<Vec<f64>, &'static str> {
+) -> Result<Vec<f64>, MathError> {
     if alpha < 0.0 || alpha > 1.0 {
-        return Err(
-            "Invalid rolloff parameter alpha, must be 0.0 <= alpha <= 1.0",
-        );
+        return Err(MathError::InvalidRolloffError);
     };
 
     // We want an odd number of taps

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -297,9 +297,10 @@ pub fn qfilt_taps(
     sam_per_sym: u32,
     fs: f64,
 ) -> Result<Vec<f64>, &'static str> {
-
     if alpha < 0.0 || alpha > 1.0 {
-        return Err("Invalid rolloff parameter alpha, must be 0.0 <= alpha <= 1.0");
+        return Err(
+            "Invalid rolloff parameter alpha, must be 0.0 <= alpha <= 1.0",
+        );
     };
 
     let d = ((n_taps as f64) / 2.0) as i32;
@@ -311,7 +312,7 @@ pub fn qfilt_taps(
     for tt in ttarr {
         let two_alpha_tt = 2.0 * alpha * tt;
         if two_alpha_tt.abs() == 1.0 {
-            output.push(alpha / PI);
+            output.push((PI * alpha * tt).sin() / (8.0 * tt));
         } else {
             let numerator = alpha * (PI * alpha * tt).cos();
             let denominator = PI * (1.0 - (two_alpha_tt * two_alpha_tt));
@@ -478,7 +479,7 @@ mod test {
             Complex::new(0.03564605925347896, 0.0),
             Complex::new(0.045015815807855304, 0.0),
             Complex::new(0.05413863102246848, 0.0),
-            Complex::new(0.07957747154594767, 0.0),
+            Complex::new(0.0625, 0.0),
             Complex::new(0.06960681131460235, 0.0),
             Complex::new(0.07502635967975885, 0.0),
             Complex::new(0.07842133035765372, 0.0),
@@ -486,7 +487,7 @@ mod test {
             Complex::new(0.07842133035765372, 0.0),
             Complex::new(0.07502635967975885, 0.0),
             Complex::new(0.06960681131460235, 0.0),
-            Complex::new(0.07957747154594767, 0.0),
+            Complex::new(0.0625, 0.0),
             Complex::new(0.05413863102246848, 0.0),
             Complex::new(0.045015815807855304, 0.0),
             Complex::new(0.03564605925347896, 0.0),

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -267,6 +267,33 @@ where
     Some(taps)
 }
 
+pub fn qfilt_taps(
+    n_taps: u32,
+    alpha: f64,
+    sam_per_sym: u32,
+    fs: f64,
+) -> Result<Vec<f64>, &'static str> {
+
+    if alpha < 0.0 || alpha > 1.0 {
+        return Err("Invalid rolloff parameter alpha, must be 0.0 <= alpha <= 1.0");
+    };
+
+    let d = ((n_taps as f64) / 2.0) as i32;
+    let ttarr: Vec<f64> = (0..n_taps)
+        .map(|x| (x as i32 - d) as f64 / (fs * sam_per_sym as f64))
+        .collect();
+
+    let mut output = vec![];
+    for tt in ttarr {
+        let numerator = alpha * (PI * alpha * tt).cos();
+        let two_alpha_tt = 2.0 * alpha * tt;
+        let denominator = PI * (1.0 - (two_alpha_tt * two_alpha_tt));
+        output.push(numerator / denominator);
+    }
+
+    Ok(output)
+}
+
 #[cfg(test)]
 mod test {
     use crate::util::math;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,33 @@
 //! Utility nodes that don't fit into any specific category and helper
 //! functions for developing your own nodes.
 
+use std::error;
+use std::fmt;
+
+#[derive(Clone, Debug)]
+pub enum MathError {
+    ConvertError,
+    InvalidRolloffError,
+}
+
+impl fmt::Display for MathError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let desc = match *self {
+            MathError::ConvertError => "Type conversion from generic failed",
+            MathError::InvalidRolloffError => {
+                "Invalid rolloff parameter, must be on interval [0.0, 1.0]"
+            }
+        };
+        write!(f, "Math error: {}", desc)
+    }
+}
+
+impl error::Error for MathError {
+    fn cause(&self) -> Option<&dyn error::Error> {
+        None
+    }
+}
+
 /// Some basic math functions used elsewhere in the project
 pub mod math;
 /// Node for creating an OpenGL window and plotting data

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -22,11 +22,7 @@ impl fmt::Display for MathError {
     }
 }
 
-impl error::Error for MathError {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        None
-    }
-}
+impl error::Error for MathError {}
 
 /// Some basic math functions used elsewhere in the project
 pub mod math;


### PR DESCRIPTION
Added the non data aided feedforward maximum likelihood timing estimator for linear modulations derived in Mengali Chp. 8.4.  This block will be critical for synchronization in demodulation of bursty signals.

Passes clippy and is formatted, and I don't really expect you to follow the math, but please check to see if I'm doing anything obviously inefficient or stupid.