### PR TITLE
Feature/phase estimator

### DIFF
--- a/src/demodulation/mod.rs
+++ b/src/demodulation/mod.rs
@@ -1,4 +1,4 @@
 //! Nodes for demodulating signals.
 pub mod nco;
-pub mod timing_estimator;
 pub mod phase_estimator;
+pub mod timing_estimator;

--- a/src/demodulation/mod.rs
+++ b/src/demodulation/mod.rs
@@ -1,2 +1,3 @@
 //! Nodes for demodulating signals.
 pub mod nco;
+pub mod phase_estimator;

--- a/src/demodulation/phase_estimator.rs
+++ b/src/demodulation/phase_estimator.rs
@@ -1,5 +1,3 @@
-extern crate num; // 0.2.0
-
 use num::complex::Complex;
 
 /// Calculates a phase estimate from the input PSK symbol vector.

--- a/src/demodulation/phase_estimator.rs
+++ b/src/demodulation/phase_estimator.rs
@@ -55,12 +55,12 @@ pub fn psk_phase_estimate(symbols: &[Complex<f64>], m: u32) -> f64 {
 /// let m = 4;
 /// let data: Vec<_> = (0..100).map(|x| Complex::new(0.0, x as f64).exp()).collect();
 ///
-/// let estimate = qam_phase_estimate(&data, m);
+/// let estimate = qam_phase_estimate(&data);
 /// ```
 pub fn qam_phase_estimate(symbols: &[Complex<f64>]) -> f64 {
     symbols
         .iter()
-        .map(|x| x.powi(4))
+        .map(|x| -1.0 * x.powi(4))
         .sum::<Complex<f64>>()
         .arg()
         / 4.0
@@ -100,8 +100,6 @@ mod test {
 
     #[test]
     fn test_qam_phase_estimator() {
-        // TODO: Fix this test!
-
         // 16 QAM
         let truth = 0.123456;
 
@@ -115,17 +113,16 @@ mod test {
             .iter()
             .map(|x| {
                 Complex::new(
-                    (x % 4) as f64 - 1.5,
+                    (*x % 4) as f64 - 1.5,
                     ((*x as f64) / 4.0).trunc() - 1.5,
                 )
             })
-            .map(|x| x * Complex::new(0.0, truth).exp())
+            .map(|x| 2.0 * x * Complex::new(0.0, truth).exp())
             .collect();
 
         // Create estimator
         let estimate = qam_phase_estimate(&symbols);
-        println!("{}", estimate);
 
-        assert!((truth - estimate).abs() < 0.000001);
+        assert!((truth - estimate).abs() < 0.01);
     }
 }

--- a/src/demodulation/phase_estimator.rs
+++ b/src/demodulation/phase_estimator.rs
@@ -1,0 +1,82 @@
+use std::f64::consts::PI;
+
+extern crate num; // 0.2.0
+
+use num::complex::Complex;
+
+// Reference Chp. 5.7.4 in Mengali
+//
+
+/// Calculates a phase estimate from the input PSK symbol vector.
+///
+/// Result is in radians, and the estimator assumes the input symbol vector is
+/// the output from a matched filter.  It additionally  assumes the vector has
+/// already gone through accurate timing recovery.
+///
+/// # Arguments
+///
+/// * `symbols` - Input vector of symbols to calculate the phase estimate from.
+///
+/// # Examples
+///
+/// ```
+/// use comms_rs::demodulation::phase_estimator::*;
+/// use num::Complex;
+///
+/// let m = 4;
+/// let data: Vec<_> = (0..100).map(|x| Complex::new(0.0, x as f64).exp()).collect();
+///
+/// let estimate = psk_phase_estimate(&data);
+/// ```
+pub fn psk_phase_estimate(m: u32, symbols: &[Complex<f64>]) -> f64 {
+    symbols.iter().map(|x| x.powi(m)).sum().arg() / (m as f64)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::demodulation::timing_estimator::*;
+    use num::Complex;
+    use rand::distributions::Uniform;
+    use rand::prelude::*;
+    use rand::rngs::SmallRng;
+    use std::f64::consts::PI;
+
+    #[test]
+    fn test_phase_estimator() {
+        let alpha = 0.5;
+        let sam_per_sym = 10;
+
+        // Generate QPSK signal
+        let mut rng = SmallRng::seed_from_u64(0);
+        let interval = Uniform::new(0, 4);
+        let data: Vec<_> = (0..1000)
+            .map(|_| rng.sample(interval))
+            .map(|x| {
+                Complex::new(0.0, 2.0 * PI * x as f64 / 4.0 + PI / 4.0).exp()
+            })
+            .collect();
+
+        let mut symbols = vec![];
+        for pt in data {
+            symbols.push(pt);
+            for _ in 1..sam_per_sym {
+                symbols.push(Complex::new(0.0, 0.0));
+            }
+        }
+
+        let n_taps = sam_per_sym * 10 + 1;
+        let rrctaps = rrc_taps(n_taps, sam_per_sym as f64, alpha).unwrap();
+        let mut state = vec![Complex::new(0.0, 0.0); n_taps as usize];
+        let samples = batch_fir(&symbols, &rrctaps, &mut state);
+
+        // Create estimator
+        let truth = 2;
+        let n = sam_per_sym;
+        let d = 5;
+        let mut estimator = TimingEstimator::new(n, d, alpha).unwrap();
+        let estimate = estimator.push(&samples[truth..]);
+        println!("{}", estimate);
+
+        assert!((truth as f64 + estimate).abs() < 0.01);
+    }
+}


### PR DESCRIPTION
Create a couple of basic functions for estimating PSK and QAM phase offset in a feedforward clock aided context.  Again useful for bursty transmissions, but assumes that the carrier and timing recovery have already occurred, and that the input has also been through a matched filter.

Same as usual guys, find my stupid mistakes.