### PR TITLE
Add Syntax Highlighting to README Code Snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To derive the trait, there are a few requirements that much be met.
 
 Example:
 
-```
+```rust
 #[derive(Node)]
 pub struct ExampleNode {
     input1: NodeReceiver<u32>,


### PR DESCRIPTION
GitHub style Markdown supports syntax highlighting for a plethora of languages. With this change we get pretty colors in the README.

Everyone likes colors.