### PR TITLE
Changing names of node outputs from `sender` to `output`

### DIFF
--- a/examples/bpsk_mod.rs
+++ b/examples/bpsk_mod.rs
@@ -149,10 +149,10 @@ fn main() {
         let mut convert = convert.lock().unwrap();
         let mut iq_out = iq_out.lock().unwrap();
         let mut upsample = upsample.lock().unwrap();
-        graph.connect_nodes(&mut rand_bits.sender, &mut bpsk_node.input, None);
+        graph.connect_nodes(&mut rand_bits.output, &mut bpsk_node.input, None);
         graph.connect_nodes(&mut bpsk_node.output, &mut upsample.input, None);
         graph.connect_nodes(&mut upsample.output, &mut pulse_shape.input, None);
-        graph.connect_nodes(&mut pulse_shape.sender, &mut convert.input, None);
+        graph.connect_nodes(&mut pulse_shape.output, &mut convert.input, None);
         graph.connect_nodes(&mut convert.output, &mut iq_out.input, None);
     }
 

--- a/examples/fm_radio.rs
+++ b/examples/fm_radio.rs
@@ -66,14 +66,14 @@ fn main() {
     #[pass_by_ref]
     struct ConvertNode {
         pub input: NodeReceiver<Vec<u8>>,
-        pub sender: NodeSender<Vec<Complex<f32>>>,
+        pub output: NodeSender<Vec<Complex<f32>>>,
     }
 
     impl ConvertNode {
         pub fn new() -> Self {
             ConvertNode {
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             }
         }
 
@@ -100,14 +100,14 @@ fn main() {
     #[pass_by_ref]
     struct Convert2Node {
         pub input: NodeReceiver<Vec<f32>>,
-        pub sender: NodeSender<Vec<Complex<f32>>>,
+        pub output: NodeSender<Vec<Complex<f32>>>,
     }
 
     impl Convert2Node {
         pub fn new() -> Self {
             Convert2Node {
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             }
         }
 
@@ -125,14 +125,14 @@ fn main() {
     #[pass_by_ref]
     struct Convert3Node {
         pub input: NodeReceiver<Vec<Complex<f32>>>,
-        pub sender: NodeSender<Vec<f32>>,
+        pub output: NodeSender<Vec<f32>>,
     }
 
     impl Convert3Node {
         pub fn new() -> Self {
             Convert3Node {
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             }
         }
 
@@ -207,19 +207,19 @@ fn main() {
     let mut mag: MagnitudeNode = MagnitudeNode::new();
     let mut plot = PlotNode::new(figure_conf, 32768, false);
 
-    connect_nodes!(sdr, sender, convert, input);
-    connect_nodes!(convert, sender, filt1, input);
-    connect_nodes!(convert, sender, fft, input);
-    connect_nodes!(fft, sender, mag, input);
+    connect_nodes!(sdr, output, convert, input);
+    connect_nodes!(convert, output, filt1, input);
+    connect_nodes!(convert, output, fft, input);
+    connect_nodes!(fft, output, mag, input);
     connect_nodes!(mag, output, dec3, input);
-    connect_nodes!(dec3, sender, plot, input);
-    connect_nodes!(filt1, sender, dec1, input);
-    connect_nodes!(dec1, sender, fm, input);
-    connect_nodes!(fm, sender, convert2, input);
-    connect_nodes!(convert2, sender, filt2, input);
-    connect_nodes!(filt2, sender, convert3, input);
-    connect_nodes!(convert3, sender, dec2, input);
-    connect_nodes!(dec2, sender, audio, input);
+    connect_nodes!(dec3, output, plot, input);
+    connect_nodes!(filt1, output, dec1, input);
+    connect_nodes!(dec1, output, fm, input);
+    connect_nodes!(fm, output, convert2, input);
+    connect_nodes!(convert2, output, filt2, input);
+    connect_nodes!(filt2, output, convert3, input);
+    connect_nodes!(convert3, output, dec2, input);
+    connect_nodes!(dec2, output, audio, input);
     start_nodes!(
         sdr, convert, filt1, dec1, fm, convert2, filt2, dec2, convert3, audio,
         dec3, fft, mag, plot,

--- a/examples/play_audio.rs
+++ b/examples/play_audio.rs
@@ -15,14 +15,14 @@ fn main() {
     #[derive(Node)]
     struct SineNode {
         source: Box<dyn Source<Item = f32> + Send>,
-        pub sender: NodeSender<Vec<f32>>,
+        pub output: NodeSender<Vec<f32>>,
     }
 
     impl SineNode {
         pub fn new(source: Box<dyn Source<Item = f32> + Send>) -> Self {
             SineNode {
                 source,
-                sender: Default::default(),
+                output: Default::default(),
             }
         }
 
@@ -35,7 +35,7 @@ fn main() {
 
     let mut sine = SineNode::new(Box::new(source::SineWave::new(440)));
 
-    connect_nodes!(sine, sender, audio, input);
+    connect_nodes!(sine, output, audio, input);
     start_nodes!(sine, audio);
     loop {}
 }

--- a/examples/qpsk_zmq.rs
+++ b/examples/qpsk_zmq.rs
@@ -21,12 +21,12 @@ fn main() {
 
     #[derive(Node)]
     struct QpskMod {
-        pub sender: NodeSender<Vec<Complex<f32>>>,
+        pub output: NodeSender<Vec<Complex<f32>>>,
     }
     impl QpskMod {
         pub fn new() -> Self {
             QpskMod {
-                sender: Default::default(),
+                output: Default::default(),
             }
         }
 
@@ -66,7 +66,7 @@ fn main() {
     let mut zmq_out =
         ZMQSend::new("tcp://127.0.0.1:57324", zmq::SocketType::PUSH, 0);
 
-    connect_nodes!(qpsk_mod_node, sender, zmq_out, input);
+    connect_nodes!(qpsk_mod_node, output, zmq_out, input);
     start_nodes!(qpsk_mod_node, zmq_out);
 
     thread::sleep(time::Duration::from_millis(10000));

--- a/src/demodulation/nco.rs
+++ b/src/demodulation/nco.rs
@@ -85,7 +85,7 @@ impl Nco {
 pub struct NcoNode {
     pub input: NodeReceiver<f64>,
     nco: Nco,
-    pub sender: NodeSender<Complex<f64>>,
+    pub output: NodeSender<Complex<f64>>,
 }
 
 impl NcoNode {
@@ -116,12 +116,12 @@ impl NcoNode {
             Some(ph) => NcoNode {
                 nco: Nco::new(ph, dphase),
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             },
             None => NcoNode {
                 nco: Nco::new(0.0, dphase),
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             },
         }
     }

--- a/src/demodulation/timing_estimator.rs
+++ b/src/demodulation/timing_estimator.rs
@@ -118,7 +118,7 @@ impl TimingEstimator {
 pub struct TimingEstimatorNode {
     pub input: NodeReceiver<Vec<Complex<f64>>>,
     timing_estimator: TimingEstimator,
-    pub sender: NodeSender<f64>,
+    pub output: NodeSender<f64>,
 }
 
 impl TimingEstimatorNode {
@@ -127,7 +127,7 @@ impl TimingEstimatorNode {
         Ok(Self {
             input: Default::default(),
             timing_estimator,
-            sender: Default::default(),
+            output: Default::default(),
         })
     }
 
@@ -195,13 +195,13 @@ mod test {
     fn test_timing_estimator_node() {
         #[derive(Node)]
         struct SendNode {
-            pub sender: NodeSender<Vec<Complex<f64>>>,
+            pub output: NodeSender<Vec<Complex<f64>>>,
         }
 
         impl SendNode {
             pub fn new() -> Self {
                 Self {
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -240,8 +240,8 @@ mod test {
         let mut send_node = SendNode::new();
         let mut timing_node = TimingEstimatorNode::new(n, d, alpha).unwrap();
         let mut check_node = CheckNode::new();
-        connect_nodes!(send_node, sender, timing_node, input);
-        connect_nodes!(timing_node, sender, check_node, input);
+        connect_nodes!(send_node, output, timing_node, input);
+        connect_nodes!(timing_node, output, check_node, input);
         start_nodes!(send_node, timing_node);
         let check = thread::spawn(move || {
             check_node.call().unwrap();

--- a/src/fft/fft_node.rs
+++ b/src/fft/fft_node.rs
@@ -31,7 +31,7 @@ where
 {
     pub input: NodeReceiver<Vec<Complex<T>>>,
     batch_fft: BatchFFT,
-    pub sender: NodeSender<Vec<Complex<T>>>,
+    pub output: NodeSender<Vec<Complex<T>>>,
 }
 
 impl<T> FFTBatchNode<T>
@@ -69,7 +69,7 @@ where
         FFTBatchNode {
             batch_fft,
             input: Default::default(),
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -107,7 +107,7 @@ where
 {
     pub input: NodeReceiver<Complex<T>>,
     sample_fft: SampleFFT<T>,
-    pub sender: NodeSender<Vec<Complex<T>>>,
+    pub output: NodeSender<Vec<Complex<T>>>,
 }
 
 impl<T> FFTSampleNode<T>
@@ -146,7 +146,7 @@ where
         FFTSampleNode {
             sample_fft,
             input: Default::default(),
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -180,13 +180,13 @@ mod test {
     fn test_fft_batch() {
         #[derive(Node)]
         struct SendNode {
-            pub sender: NodeSender<Vec<Complex<f32>>>,
+            pub output: NodeSender<Vec<Complex<f32>>>,
         }
 
         impl SendNode {
             pub fn new() -> Self {
                 SendNode {
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -247,8 +247,8 @@ mod test {
         }
         let mut check_node = CheckNode::new();
 
-        connect_nodes!(send_node, sender, fft_node, input);
-        connect_nodes!(fft_node, sender, check_node, input);
+        connect_nodes!(send_node, output, fft_node, input);
+        connect_nodes!(fft_node, output, check_node, input);
         start_nodes!(send_node, fft_node);
         let check = thread::spawn(move || {
             let now = Instant::now();
@@ -267,14 +267,14 @@ mod test {
         #[derive(Node)]
         struct SendNode {
             state: Vec<Complex<f32>>,
-            pub sender: NodeSender<Complex<f32>>,
+            pub output: NodeSender<Complex<f32>>,
         }
 
         impl SendNode {
             pub fn new(state: Vec<Complex<f32>>) -> Self {
                 SendNode {
                     state,
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -335,8 +335,8 @@ mod test {
         }
         let mut check_node = CheckNode::new();
 
-        connect_nodes!(send_node, sender, fft_node, input);
-        connect_nodes!(fft_node, sender, check_node, input);
+        connect_nodes!(send_node, output, fft_node, input);
+        connect_nodes!(fft_node, output, check_node, input);
         start_nodes!(send_node, fft_node);
         let check = thread::spawn(move || {
             check_node.call().unwrap();

--- a/src/filter/fir_node.rs
+++ b/src/filter/fir_node.rs
@@ -51,7 +51,7 @@ where
     pub input: NodeReceiver<Complex<T>>,
     taps: Vec<Complex<T>>,
     state: Vec<Complex<T>>,
-    pub sender: NodeSender<Complex<T>>,
+    pub output: NodeSender<Complex<T>>,
 }
 
 impl<T> FirNode<T>
@@ -94,7 +94,7 @@ where
                 taps,
                 state: st,
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             },
             None => {
                 let len = taps.len();
@@ -102,7 +102,7 @@ where
                     taps,
                     state: vec![Complex::zero(); len],
                     input: Default::default(),
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
         }
@@ -154,7 +154,7 @@ where
     pub input: NodeReceiver<Vec<Complex<T>>>,
     taps: Vec<Complex<T>>,
     state: Vec<Complex<T>>,
-    pub sender: NodeSender<Vec<Complex<T>>>,
+    pub output: NodeSender<Vec<Complex<T>>>,
 }
 
 impl<T> BatchFirNode<T>
@@ -198,7 +198,7 @@ where
                 taps,
                 state: st,
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             },
             None => {
                 let len = taps.len();
@@ -206,7 +206,7 @@ where
                     taps,
                     state: vec![Complex::zero(); len],
                     input: Default::default(),
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
         }
@@ -238,14 +238,14 @@ mod test {
         #[derive(Node)]
         struct SomeSamples {
             samples: Vec<Complex<i16>>,
-            sender: NodeSender<Complex<i16>>,
+            output: NodeSender<Complex<i16>>,
         }
 
         impl SomeSamples {
             pub fn new(samples: Vec<Complex<i16>>) -> Self {
                 SomeSamples {
                     samples,
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -324,8 +324,8 @@ mod test {
 
         let mut check_node = CheckNode::new();
 
-        connect_nodes!(source, sender, mynode, input);
-        connect_nodes!(mynode, sender, check_node, input);
+        connect_nodes!(source, output, mynode, input);
+        connect_nodes!(mynode, output, check_node, input);
         start_nodes!(source, mynode);
         let check = thread::spawn(move || {
             let now = Instant::now();
@@ -345,14 +345,14 @@ mod test {
         #[derive(Node)]
         struct SomeSamples {
             samples: Vec<Complex<i16>>,
-            pub sender: NodeSender<Vec<Complex<i16>>>,
+            pub output: NodeSender<Vec<Complex<i16>>>,
         }
 
         impl SomeSamples {
             pub fn new(samples: Vec<Complex<i16>>) -> Self {
                 SomeSamples {
                     samples,
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -435,8 +435,8 @@ mod test {
 
         let mut check_node = CheckNode::new();
 
-        connect_nodes!(source, sender, mynode, input);
-        connect_nodes!(mynode, sender, check_node, input);
+        connect_nodes!(source, output, mynode, input);
+        connect_nodes!(mynode, output, check_node, input);
         start_nodes!(source, mynode);
         let check = thread::spawn(move || {
             let now = Instant::now();

--- a/src/hardware/radio.rs
+++ b/src/hardware/radio.rs
@@ -57,7 +57,7 @@ where
     radio: T,
     input_idx: usize,
     num_samples: usize,
-    pub sender: NodeSender<Vec<U>>,
+    pub output: NodeSender<Vec<U>>,
 }
 
 impl<T, U> RadioRxNode<T, U>
@@ -70,7 +70,7 @@ where
             radio,
             input_idx,
             num_samples,
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 

--- a/src/hardware/rtlsdr_radio.rs
+++ b/src/hardware/rtlsdr_radio.rs
@@ -81,7 +81,7 @@ mod test {
         #[derive(Node)]
         #[pass_by_ref]
         struct CheckNode {
-            recv: NodeReceiver<Vec<u8>>,
+            input: NodeReceiver<Vec<u8>>,
             num_samples: usize,
         }
 
@@ -89,7 +89,7 @@ mod test {
             pub fn new(num_samples: usize) -> Self {
                 CheckNode {
                     num_samples,
-                    recv: Default::default(),
+                    input: Default::default(),
                 }
             }
 
@@ -100,7 +100,7 @@ mod test {
         }
 
         let mut check_node = CheckNode::new(num_samples);
-        connect_nodes!(sdr_node, sender, check_node, recv);
+        connect_nodes!(sdr_node, output, check_node, input);
         start_nodes!(sdr_node);
         let check = thread::spawn(move || {
             let now = Instant::now();

--- a/src/io/raw_iq.rs
+++ b/src/io/raw_iq.rs
@@ -23,7 +23,7 @@ where
     R: Read + Send,
 {
     reader: R,
-    pub sender: NodeSender<IQSample>,
+    pub output: NodeSender<IQSample>,
 }
 
 impl<R: Read + Send> IQInput<R> {
@@ -42,7 +42,7 @@ impl<R: Read + Send> IQInput<R> {
     pub fn new(reader: R) -> Self {
         IQInput {
             reader,
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -81,7 +81,7 @@ where
 {
     reader: R,
     batch_size: usize,
-    pub sender: NodeSender<Vec<IQSample>>,
+    pub output: NodeSender<Vec<IQSample>>,
 }
 
 /// Will retrieve samples as interleaved 16-bit values in host byte-order from
@@ -103,7 +103,7 @@ impl<R: Read + Send> IQBatchInput<R> {
         IQBatchInput {
             reader,
             batch_size,
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 

--- a/src/io/zmq_node.rs
+++ b/src/io/zmq_node.rs
@@ -36,7 +36,7 @@ where
     /// let mut rand = rand_node::NormalNode::new(0.0, 1.0);
     /// let mut send: ZMQSend<f64> = ZMQSend::new("tcp://*:5556",
     ///     zmq::SocketType::PUB, 0);
-    /// connect_nodes!(rand, sender, send, input);
+    /// connect_nodes!(rand, output, send, input);
     /// start_nodes!(rand, send);
     /// # }
     pub fn new(
@@ -78,7 +78,7 @@ where
 {
     socket: zmq::Socket,
     flags: i32,
-    pub sender: NodeSender<T>,
+    pub output: NodeSender<T>,
 }
 
 impl<T> ZMQRecv<T>
@@ -104,7 +104,7 @@ where
     ///     zmq::SocketType::SUB,
     ///     0);
     /// let mut fft: FFTBatchNode<u32> = FFTBatchNode::new(1024, false);
-    /// connect_nodes!(recv, sender, fft, input);
+    /// connect_nodes!(recv, output, fft, input);
     /// start_nodes!(recv, fft);
     /// # }
     pub fn new(
@@ -119,7 +119,7 @@ where
         ZMQRecv {
             socket,
             flags,
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -151,12 +151,12 @@ mod test {
     fn test_zmq() {
         #[derive(Node)]
         struct DataGen {
-            pub sender: NodeSender<Vec<u32>>,
+            pub output: NodeSender<Vec<u32>>,
         }
         impl DataGen {
             pub fn new() -> Self {
                 DataGen {
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -190,8 +190,8 @@ mod test {
             }
         }
         let mut check_node = CheckNode::new();
-        connect_nodes!(data_node, sender, zmq_send, input);
-        connect_nodes!(zmq_recv, sender, check_node, input);
+        connect_nodes!(data_node, output, zmq_send, input);
+        connect_nodes!(zmq_recv, output, check_node, input);
         start_nodes!(data_node, zmq_send, zmq_recv);
 
         let handle = thread::spawn(move || {

--- a/src/mixer.rs
+++ b/src/mixer.rs
@@ -98,7 +98,7 @@ where
 {
     pub input: NodeReceiver<Complex<T>>,
     mixer: Mixer,
-    pub sender: NodeSender<Complex<T>>,
+    pub output: NodeSender<Complex<T>>,
 }
 
 impl<T> MixerNode<T>
@@ -132,12 +132,12 @@ where
             Some(ph) => MixerNode {
                 mixer: Mixer::new(ph, dphase),
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             },
             None => MixerNode {
                 mixer: Mixer::new(0.0, dphase),
                 input: Default::default(),
-                sender: Default::default(),
+                output: Default::default(),
             },
         }
     }
@@ -164,14 +164,14 @@ mod test {
         #[derive(Node)]
         struct SomeSamples {
             samples: Vec<Complex<f64>>,
-            pub sender: NodeSender<Complex<f64>>,
+            pub output: NodeSender<Complex<f64>>,
         }
 
         impl SomeSamples {
             pub fn new(samples: Vec<Complex<f64>>) -> Self {
                 SomeSamples {
                     samples,
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -233,8 +233,8 @@ mod test {
 
         let mut check_node = CheckNode::new();
 
-        connect_nodes!(source, sender, mixer, input);
-        connect_nodes!(mixer, sender, check_node, input);
+        connect_nodes!(source, output, mixer, input);
+        connect_nodes!(mixer, output, check_node, input);
         start_nodes!(source, mixer);
         let check = thread::spawn(move || {
             let now = Instant::now();
@@ -254,14 +254,14 @@ mod test {
         #[derive(Node)]
         struct SomeSamples {
             samples: Vec<Complex<f64>>,
-            pub sender: NodeSender<Complex<f64>>,
+            pub output: NodeSender<Complex<f64>>,
         }
 
         impl SomeSamples {
             pub fn new(samples: Vec<Complex<f64>>) -> Self {
                 SomeSamples {
                     samples,
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -323,8 +323,8 @@ mod test {
 
         let mut check_node = CheckNode::new();
 
-        connect_nodes!(source, sender, mixer, input);
-        connect_nodes!(mixer, sender, check_node, input);
+        connect_nodes!(source, output, mixer, input);
+        connect_nodes!(mixer, output, check_node, input);
         start_nodes!(source, mixer);
         let check = thread::spawn(move || {
             let now = Instant::now();

--- a/src/modulation/analog_node.rs
+++ b/src/modulation/analog_node.rs
@@ -23,7 +23,7 @@ where
 {
     pub input: NodeReceiver<Vec<Complex<T>>>,
     fm: analog::FM<T>,
-    pub sender: NodeSender<Vec<T>>,
+    pub output: NodeSender<Vec<T>>,
 }
 
 impl<T> FMDemodNode<T>

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -13,13 +13,13 @@
 //! // inputs, the receivers must explicitly be named.
 //! #[derive(Node)]
 //! struct Node1 {
-//!     pub sender: NodeSender<u32>,
+//!     pub output: NodeSender<u32>,
 //! }
 //!
 //! impl Node1 {
 //!     pub fn new() -> Self {
 //!         Node1 {
-//!             sender: Default::default(),
+//!             output: Default::default(),
 //!         }
 //!     }
 //!
@@ -52,8 +52,8 @@
 //! let mut node2 = Node2::new();
 //!
 //! // Create a connection between two nodes: node1 sending messages and node2
-//! // receiving on the `recv` receiver in the Node2 structure.
-//! connect_nodes!(node1, sender, node2, input);
+//! // receiving on the `input` receiver in the Node2 structure.
+//! connect_nodes!(node1, output, node2, input);
 //!
 //! // Spawn threads for node1 and node2 and have them executing indefinitely.
 //! start_nodes!(node1, node2);
@@ -105,13 +105,13 @@ pub trait Node: Send {
 /// # fn main() {
 /// # #[derive(Node)]
 /// # struct Node1 {
-/// #     sender: NodeSender<u32>,
+/// #     output: NodeSender<u32>,
 /// # }
 /// #
 /// # impl Node1 {
 /// #   pub fn new() -> Self {
 /// #       Node1 {
-/// #           sender: Default::default(),
+/// #           output: Default::default(),
 /// #       }
 /// #   }
 /// #
@@ -122,13 +122,13 @@ pub trait Node: Send {
 /// #
 /// # #[derive(Node)]
 /// # struct Node2 {
-/// #   recv: NodeReceiver<u32>,
+/// #   input: NodeReceiver<u32>,
 /// # }
 /// #
 /// # impl Node2 {
 /// #   pub fn new() -> Self {
 /// #       Node2 {
-/// #           recv: Default::default(),
+/// #           input: Default::default(),
 /// #       }
 /// #   }
 /// #
@@ -141,8 +141,8 @@ pub trait Node: Send {
 /// let mut node2 = Node2::new();
 ///
 /// // node1 will now send its messages to node2. node2 will receive the
-/// // message on its receiver named `recv`.
-/// connect_nodes!(node1, sender, node2, recv);
+/// // message on its receiver named `input`.
+/// connect_nodes!(node1, output, node2, input);
 /// # }
 /// ```
 ///
@@ -166,13 +166,13 @@ macro_rules! connect_nodes {
 /// # fn main() {
 /// # #[derive(Node)]
 /// # struct Node1 {
-/// #     sender: NodeSender<u32>,
+/// #     output: NodeSender<u32>,
 /// # }
 /// #
 /// # impl Node1 {
 /// #   pub fn new() -> Self {
 /// #       Node1 {
-/// #           sender: Default::default(),
+/// #           output: Default::default(),
 /// #       }
 /// #   }
 /// #
@@ -183,13 +183,13 @@ macro_rules! connect_nodes {
 /// #
 /// # #[derive(Node)]
 /// # struct Node2 {
-/// #   recv: NodeReceiver<u32>,
+/// #   input: NodeReceiver<u32>,
 /// # }
 /// #
 /// # impl Node2 {
 /// #   pub fn new() -> Self {
 /// #       Node2 {
-/// #           recv: Default::default(),
+/// #           input: Default::default(),
 /// #       }
 /// #   }
 /// #
@@ -202,10 +202,10 @@ macro_rules! connect_nodes {
 /// let mut node2 = Node2::new();
 ///
 /// // node1 will now send its messages to node2. node2 will receive the
-/// // message on its receiver named `recv`. When node1 starts, it will send
+/// // message on its receiver named `input`. When node1 starts, it will send
 /// // a 0 to node2 the first time it's run by start_nodes! and run a normal
 /// // loop afterwards.
-/// connect_nodes_feedback!(node1, sender, node2, recv, 0);
+/// connect_nodes_feedback!(node1, output, node2, input, 0);
 /// # }
 /// ```
 ///
@@ -230,13 +230,13 @@ macro_rules! connect_nodes_feedback {
 /// # fn main() {
 /// # #[derive(Node)]
 /// # struct Node1 {
-/// #     pub sender: NodeSender<u32>,
+/// #     pub output: NodeSender<u32>,
 /// # }
 ///
 /// # impl Node1 {
 /// #     pub fn new() -> Self {
 /// #         Node1 {
-/// #             sender: Default::default(),
+/// #             output: Default::default(),
 /// #         }
 /// #     }
 /// #
@@ -264,7 +264,7 @@ macro_rules! connect_nodes_feedback {
 /// # }
 /// # let mut node1 = Node1::new();
 /// # let mut node2 = Node2::new();
-/// # connect_nodes!(node1, sender, node2, input);
+/// # connect_nodes!(node1, output, node2, input);
 ///
 /// // Connect two nodes named node1 and node2. node1 will now send its
 /// // messages to node2. node2 will receive the
@@ -297,13 +297,13 @@ macro_rules! start_nodes {
 /// # fn main() {
 /// # #[derive(Node)]
 /// # struct Node1 {
-/// #     pub sender: NodeSender<u32>,
+/// #     pub output: NodeSender<u32>,
 /// # }
 ///
 /// # impl Node1 {
 /// #     pub fn new() -> Self {
 /// #         Node1 {
-/// #             sender: Default::default(),
+/// #             output: Default::default(),
 /// #         }
 /// #     }
 /// #
@@ -331,10 +331,10 @@ macro_rules! start_nodes {
 /// # }
 /// # let mut node1 = Node1::new();
 /// # let mut node2 = Node2::new();
-/// # connect_nodes!(node1, sender, node2, input);
+/// # connect_nodes!(node1, output, node2, input);
 /// // Connect two nodes named node1 and node2. node1 will now send its
 /// // messages to node2. node2 will receive the
-/// // message on its receiver named `recv`.
+/// // message on its receiver named `input`.
 /// start_nodes_threadpool!(node1, node2);
 /// # }
 /// ```
@@ -365,13 +365,13 @@ mod test {
     fn test_simple_nodes() {
         #[derive(Node)]
         struct Node1 {
-            pub sender: NodeSender<u32>,
+            pub output: NodeSender<u32>,
         }
 
         impl Node1 {
             pub fn new() -> Self {
                 Node1 {
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -401,7 +401,7 @@ mod test {
         let mut node1 = Node1::new();
         let mut node2 = Node2::new();
 
-        connect_nodes!(node1, sender, node2, input);
+        connect_nodes!(node1, output, node2, input);
         start_nodes!(node1);
         let check = thread::spawn(move || {
             let now = Instant::now();
@@ -420,13 +420,13 @@ mod test {
     fn test_simple_graph() {
         #[derive(Node)]
         struct Node1 {
-            pub sender: NodeSender<u32>,
+            pub output: NodeSender<u32>,
         }
 
         impl Node1 {
             pub fn new() -> Self {
                 Node1 {
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -466,7 +466,7 @@ mod test {
         {
             let mut node1 = node1.lock().unwrap();
             let mut node2 = node2.lock().unwrap();
-            graph.connect_nodes(&mut node1.sender, &mut node2.input, None);
+            graph.connect_nodes(&mut node1.output, &mut node2.input, None);
         }
         assert!(graph.is_connected());
         graph.run_graph();
@@ -489,14 +489,14 @@ mod test {
         #[aggregate]
         struct Node1 {
             agg: Vec<u32>,
-            pub sender: NodeSender<Arc<Vec<u32>>>,
+            pub output: NodeSender<Arc<Vec<u32>>>,
         }
 
         impl Node1 {
             pub fn new() -> Self {
                 Node1 {
                     agg: vec![],
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -516,14 +516,14 @@ mod test {
         #[pass_by_ref]
         struct Node2 {
             pub input: NodeReceiver<Arc<Vec<u32>>>,
-            pub sender: NodeSender<Arc<Vec<u32>>>,
+            pub output: NodeSender<Arc<Vec<u32>>>,
         }
 
         impl Node2 {
             pub fn new() -> Self {
                 Node2 {
                     input: Default::default(),
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -565,8 +565,8 @@ mod test {
         let mut node2 = Node2::new();
         let mut node3 = Node3::new();
 
-        connect_nodes!(node1, sender, node2, input);
-        connect_nodes!(node2, sender, node3, input);
+        connect_nodes!(node1, output, node2, input);
+        connect_nodes!(node2, output, node3, input);
         start_nodes!(node1, node2);
         let check = thread::spawn(move || {
             let now = Instant::now();
@@ -588,13 +588,13 @@ mod test {
     fn test_throughput() {
         #[derive(Node)]
         struct Node1 {
-            pub sender: NodeSender<Arc<Vec<i16>>>,
+            pub output: NodeSender<Arc<Vec<i16>>>,
         }
 
         impl Node1 {
             pub fn new() -> Self {
                 Node1 {
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -609,14 +609,14 @@ mod test {
         #[pass_by_ref]
         struct Node2 {
             pub input: NodeReceiver<Arc<Vec<i16>>>,
-            pub sender: NodeSender<Arc<Vec<i16>>>,
+            pub output: NodeSender<Arc<Vec<i16>>>,
         }
 
         impl Node2 {
             pub fn new() -> Self {
                 Node2 {
                     input: Default::default(),
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -665,8 +665,8 @@ mod test {
         let mut node2 = Node2::new();
         let mut node3 = Node3::new();
 
-        connect_nodes!(node1, sender, node2, input);
-        connect_nodes!(node2, sender, node3, input);
+        connect_nodes!(node1, output, node2, input);
+        connect_nodes!(node2, output, node3, input);
         start_nodes!(node1, node2, node3);
         thread::sleep(Duration::from_secs(1));
     }
@@ -679,13 +679,13 @@ mod test {
     fn test_threadpool_throughput() {
         #[derive(Node)]
         struct Node1 {
-            pub sender: NodeSender<Arc<Vec<i16>>>,
+            pub output: NodeSender<Arc<Vec<i16>>>,
         }
 
         impl Node1 {
             pub fn new() -> Self {
                 Node1 {
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -700,14 +700,14 @@ mod test {
         #[pass_by_ref]
         struct Node2 {
             pub input: NodeReceiver<Arc<Vec<i16>>>,
-            pub sender: NodeSender<Arc<Vec<i16>>>,
+            pub output: NodeSender<Arc<Vec<i16>>>,
         }
 
         impl Node2 {
             pub fn new() -> Self {
                 Node2 {
                     input: Default::default(),
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -756,8 +756,8 @@ mod test {
         let mut node2 = Node2::new();
         let mut node3 = Node3::new();
 
-        connect_nodes!(node1, sender, node2, input);
-        connect_nodes!(node2, sender, node3, input);
+        connect_nodes!(node1, output, node2, input);
+        connect_nodes!(node2, output, node3, input);
         start_nodes!(node1, node3);
         start_nodes_threadpool!(node2,);
         thread::sleep(Duration::from_secs(1));
@@ -811,16 +811,16 @@ mod test {
         // the receivers recv_u and recv_f.
         #[derive(Node)]
         struct DoubleInputNode {
-            recv1: NodeReceiver<u32>,
-            recv2: NodeReceiver<f64>,
+            input1: NodeReceiver<u32>,
+            input2: NodeReceiver<f64>,
             output: NodeSender<f32>,
         }
 
         impl DoubleInputNode {
             pub fn new() -> Self {
                 DoubleInputNode {
-                    recv1: Default::default(),
-                    recv2: Default::default(),
+                    input1: Default::default(),
+                    input2: Default::default(),
                     output: Default::default(),
                 }
             }
@@ -832,13 +832,13 @@ mod test {
 
         #[derive(Node)]
         struct CheckNode {
-            recv: NodeReceiver<f32>,
+            input: NodeReceiver<f32>,
         }
 
         impl CheckNode {
             pub fn new() -> Self {
                 CheckNode {
-                    recv: Default::default(),
+                    input: Default::default(),
                 }
             }
 
@@ -856,9 +856,9 @@ mod test {
 
         // Once you have your nodes, you can construct receivers and senders
         // to connect the nodes to one another.
-        connect_nodes!(node1, output, node3, recv1);
-        connect_nodes!(node2, output, node3, recv2);
-        connect_nodes!(node3, output, node4, recv);
+        connect_nodes!(node1, output, node3, input1);
+        connect_nodes!(node2, output, node3, input2);
+        connect_nodes!(node3, output, node4, input);
 
         // Lastly, start up your nodes.
         start_nodes!(node1, node2, node3,);
@@ -902,17 +902,17 @@ mod test {
 
         #[derive(Node)]
         struct CounterNode {
-            recv: NodeReceiver<i32>,
+            input: NodeReceiver<i32>,
             count: i32,
-            sender: NodeSender<i32>,
+            output: NodeSender<i32>,
         }
 
         impl CounterNode {
             pub fn new() -> Self {
                 CounterNode {
                     count: 0,
-                    recv: Default::default(),
-                    sender: Default::default(),
+                    input: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -924,7 +924,7 @@ mod test {
 
         let mut one_node = OneNode::new();
         let mut count_node = CounterNode::new();
-        connect_nodes!(one_node, output, count_node, recv);
+        connect_nodes!(one_node, output, count_node, input);
 
         thread::spawn(move || {
             for _ in 0..10 {
@@ -947,17 +947,17 @@ mod test {
     fn test_feedback() {
         #[derive(Node)]
         struct AddNode {
-            recv: NodeReceiver<i32>,
+            input: NodeReceiver<i32>,
             count: i32,
-            sender: NodeSender<i32>,
+            output: NodeSender<i32>,
         }
 
         impl AddNode {
             pub fn new() -> Self {
                 AddNode {
                     count: 1,
-                    recv: Default::default(),
-                    sender: Default::default(),
+                    input: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -969,7 +969,7 @@ mod test {
 
         #[derive(Node)]
         struct PrintNode {
-            recv: NodeReceiver<i32>,
+            input: NodeReceiver<i32>,
             count: i32,
             output: NodeSender<i32>,
         }
@@ -978,7 +978,7 @@ mod test {
             pub fn new() -> Self {
                 PrintNode {
                     count: 0,
-                    recv: Default::default(),
+                    input: Default::default(),
                     output: Default::default(),
                 }
             }
@@ -991,8 +991,8 @@ mod test {
 
         let mut add_node = AddNode::new();
         let mut print_node = PrintNode::new();
-        connect_nodes!(add_node, sender, print_node, recv);
-        connect_nodes_feedback!(print_node, output, add_node, recv, 0);
+        connect_nodes!(add_node, output, print_node, input);
+        connect_nodes_feedback!(print_node, output, add_node, input, 0);
         start_nodes!(add_node);
         let check = thread::spawn(move || {
             for (print, val) in &print_node.output {

--- a/src/prn.rs
+++ b/src/prn.rs
@@ -96,7 +96,7 @@ where
     T: PrimInt + Send,
 {
     prngen: PrnGen<T>,
-    pub sender: NodeSender<u8>,
+    pub output: NodeSender<u8>,
 }
 
 impl<T> PrnsNode<T>
@@ -124,7 +124,7 @@ where
     pub fn new(poly_mask: T, state: T) -> Self {
         PrnsNode {
             prngen: PrnGen::new(poly_mask, state),
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -192,7 +192,7 @@ mod test {
         let mut mynode = PrnsNode::new(0xC0 as u8, 0x01);
         #[derive(Node)]
         struct CheckNode {
-            recv: NodeReceiver<u8>,
+            input: NodeReceiver<u8>,
             state: Vec<u8>,
         }
 
@@ -200,7 +200,7 @@ mod test {
             pub fn new() -> Self {
                 CheckNode {
                     state: vec![],
-                    recv: Default::default(),
+                    input: Default::default(),
                 }
             }
 
@@ -228,7 +228,7 @@ mod test {
 
         let mut check_node = CheckNode::new();
 
-        connect_nodes!(mynode, sender, check_node, recv);
+        connect_nodes!(mynode, output, check_node, input);
         start_nodes!(mynode);
         let check = thread::spawn(move || {
             let now = Instant::now();

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -45,7 +45,7 @@ where
     taps: Vec<Complex<T>>,
     sam_per_sym: usize,
     state: Vec<Complex<T>>,
-    pub sender: NodeSender<Vec<Complex<T>>>,
+    pub output: NodeSender<Vec<Complex<T>>>,
 }
 
 impl<T> PulseNode<T>
@@ -77,7 +77,7 @@ where
             sam_per_sym,
             state: vec![Complex::zero(); len],
             input: Default::default(),
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -108,14 +108,14 @@ mod test {
         #[derive(Node)]
         struct SomeSamples {
             samples: Vec<Complex<i16>>,
-            sender: NodeSender<Complex<i16>>,
+            output: NodeSender<Complex<i16>>,
         }
 
         impl SomeSamples {
             pub fn new(samples: Vec<Complex<i16>>) -> Self {
                 SomeSamples {
                     samples,
-                    sender: Default::default(),
+                    output: Default::default(),
                 }
             }
 
@@ -195,8 +195,8 @@ mod test {
 
         let mut check_node = CheckNode::new();
 
-        connect_nodes!(source, sender, mynode, input);
-        connect_nodes!(mynode, sender, check_node, input);
+        connect_nodes!(source, output, mynode, input);
+        connect_nodes!(mynode, output, check_node, input);
         start_nodes!(source, mynode);
         let check = thread::spawn(move || {
             let now = Instant::now();

--- a/src/util/rand_node.rs
+++ b/src/util/rand_node.rs
@@ -30,7 +30,7 @@ where
 {
     rng: StdRng,
     dist: Uniform<T>,
-    pub sender: NodeSender<T>,
+    pub output: NodeSender<T>,
 }
 
 impl<T> UniformNode<T>
@@ -63,7 +63,7 @@ where
         UniformNode {
             rng,
             dist,
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -98,7 +98,7 @@ where
 pub struct NormalNode {
     rng: StdRng,
     dist: Normal,
-    pub sender: NodeSender<f64>,
+    pub output: NodeSender<f64>,
 }
 
 impl NormalNode {
@@ -127,7 +127,7 @@ impl NormalNode {
         NormalNode {
             rng,
             dist,
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -198,7 +198,7 @@ mod test {
             }
         }
         let mut check_node = CheckNode::new();
-        connect_nodes!(uniform_node, sender, check_node, recv);
+        connect_nodes!(uniform_node, output, check_node, recv);
         start_nodes!(uniform_node);
         let check = thread::spawn(move || {
             let now = Instant::now();
@@ -235,7 +235,7 @@ mod test {
             }
         }
         let mut check_node = CheckNode::new();
-        connect_nodes!(bit_node, sender, check_node, recv);
+        connect_nodes!(bit_node, output, check_node, recv);
         start_nodes!(bit_node);
         let check = thread::spawn(move || {
             let now = Instant::now();

--- a/src/util/resample_node.rs
+++ b/src/util/resample_node.rs
@@ -13,7 +13,7 @@ where
 {
     pub input: NodeReceiver<Vec<T>>,
     dec_rate: usize,
-    pub sender: NodeSender<Vec<T>>,
+    pub output: NodeSender<Vec<T>>,
 }
 
 impl<T> DecimateNode<T>
@@ -24,7 +24,7 @@ where
         DecimateNode {
             dec_rate,
             input: Default::default(),
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -77,7 +77,7 @@ where
 {
     pub input: NodeReceiver<Vec<T>>,
     ups_rate: usize,
-    pub sender: NodeSender<Vec<T>>,
+    pub output: NodeSender<Vec<T>>,
 }
 
 impl<T> UpsampleNode<T>
@@ -88,7 +88,7 @@ where
         UpsampleNode {
             ups_rate,
             input: Default::default(),
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 

--- a/tests/macro_tests.rs
+++ b/tests/macro_tests.rs
@@ -7,13 +7,13 @@ use std::thread;
 
 #[derive(Node)]
 pub struct Node1 {
-    sender: NodeSender<u32>,
+    output: NodeSender<u32>,
 }
 
 impl Node1 {
     fn new() -> Self {
         Node1 {
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -26,7 +26,7 @@ impl Node1 {
 pub struct Node2 {
     recv_input: NodeReceiver<u32>,
     stuff: u32,
-    sender: NodeSender<u32>,
+    output: NodeSender<u32>,
 }
 
 impl Node2 {
@@ -34,7 +34,7 @@ impl Node2 {
         Node2 {
             stuff,
             recv_input: Default::default(),
-            sender: Default::default(),
+            output: Default::default(),
         }
     }
 
@@ -70,8 +70,8 @@ fn test_macro() {
 
     let mut node3 = Node3::new();
 
-    connect_nodes!(node1, sender, node2, recv_input);
-    connect_nodes!(node2, sender, node3, recv_input);
+    connect_nodes!(node1, output, node2, recv_input);
+    connect_nodes!(node2, output, node3, recv_input);
 
     thread::spawn(move || {
         node1.call().unwrap();

--- a/tests/node_test.rs
+++ b/tests/node_test.rs
@@ -9,13 +9,13 @@ use std::time::Duration;
 fn simple_nodes() {
     #[derive(Node)]
     struct SourceNode {
-        pub sender: NodeSender<u32>,
+        pub output: NodeSender<u32>,
     }
 
     impl SourceNode {
         pub fn new() -> Self {
             SourceNode {
-                sender: Default::default(),
+                output: Default::default(),
             }
         }
 
@@ -44,7 +44,7 @@ fn simple_nodes() {
 
     let mut node = SourceNode::new();
     let mut node2 = SinkNode::new();
-    connect_nodes!(node, sender, node2, input);
+    connect_nodes!(node, output, node2, input);
     start_nodes!(node, node2);
     thread::sleep(Duration::from_secs(1));
 }


### PR DESCRIPTION
- To have a standard on names and to be more consistent with the
  `input` naming convention for node inputs, all outputs on nodes
  have been renamed to `output` versus `sender`.
- The few inputs that didn't follow the naming convention of `input`
  have been renamed as well.

Closes #119.