### PR TITLE
Windows is so dumb

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub mod hardware;
 pub mod io;
 pub mod mixer;
 pub mod modulation;
-pub mod prn;
+pub mod prns;
 pub mod pulse;
 pub mod util;
 

--- a/src/prns.rs
+++ b/src/prns.rs
@@ -53,7 +53,7 @@ impl<T: PrimInt> PrnGen<T> {
     ///
     /// # Examples
     /// ```
-    /// use comms_rs::prn::PrnGen;
+    /// use comms_rs::prns::PrnGen;
     ///
     /// let poly_mask = 0xC0_u8;
     /// let state = 0xFF_u8;
@@ -84,7 +84,7 @@ impl<T: PrimInt> PrnGen<T> {
 /// # Examples
 ///
 /// ```
-/// use comms_rs::prn::PrnsNode;
+/// use comms_rs::prns::PrnsNode;
 ///
 /// let poly_mask = 0xC0_u8;
 /// let state = 0xFF_u8;
@@ -115,7 +115,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use comms_rs::prn::PrnsNode;
+    /// use comms_rs::prns::PrnsNode;
     ///
     /// let poly_mask = 0xC0_u8;
     /// let state = 0xFF_u8;
@@ -136,7 +136,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
-    use crate::prn::*;
+    use crate::prns::*;
     use num::PrimInt;
     use std::collections::HashMap;
     use std::hash::Hash;


### PR DESCRIPTION
Apparently Windows can't handle things named `prn` because esoteric ancient shit from the 80's or something.

[Reference](https://superuser.com/questions/613313/why-cant-we-make-con-prn-null-folder-in-windows) if you hate yourself and want to be dumber.