### PR TITLE
Fix some Clippy Warnings

### DIFF
--- a/node_derive/src/lib.rs
+++ b/node_derive/src/lib.rs
@@ -25,7 +25,7 @@ struct ParsedFields<'a> {
 /// transformations on the input data structure's types depending on the name
 /// of the fields in the structure.
 ///
-/// The implementation of the Node trait depends on whether #[aggregate] is
+/// The implementation of the Node trait depends on whether `#[aggregate]` is
 /// specified on the structure or not. If it is, the Node will only send out
 /// data when it gets a Some(T) from the run() function, otherwise it will
 /// continue to the next iteration.
@@ -33,7 +33,7 @@ struct ParsedFields<'a> {
 /// This macro currently assumes that the structure in question implements a
 /// function called `run()` which is exercised in the `call()` function from
 /// the Node trait. The return type of the run() depends on whether the
-/// #[aggregate] flag is specified on the input structure. If #[aggregate] is
+/// `#[aggregate]` flag is specified on the input structure. If `#[aggregate]` is
 /// present on the structure, the return type must be an Option. Otherwise, it
 /// can be anything.
 ///
@@ -49,7 +49,7 @@ struct ParsedFields<'a> {
 ///     output: NodeSender<T>,
 /// }
 /// ```
-///  
+///
 pub fn node_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let name = &input.ident;

--- a/src/demodulation/timing_estimator.rs
+++ b/src/demodulation/timing_estimator.rs
@@ -170,7 +170,7 @@ mod test {
         let n_taps = sam_per_sym * 10 + 1;
         let rrctaps = rrc_taps(n_taps, sam_per_sym as f64, alpha).unwrap();
         let mut state = vec![Complex::new(0.0, 0.0); n_taps as usize];
-        
+
         batch_fir(&symbols, &rrctaps, &mut state)
     }
 

--- a/src/demodulation/timing_estimator.rs
+++ b/src/demodulation/timing_estimator.rs
@@ -170,8 +170,8 @@ mod test {
         let n_taps = sam_per_sym * 10 + 1;
         let rrctaps = rrc_taps(n_taps, sam_per_sym as f64, alpha).unwrap();
         let mut state = vec![Complex::new(0.0, 0.0); n_taps as usize];
-        let samples = batch_fir(&symbols, &rrctaps, &mut state);
-        samples
+        
+        batch_fir(&symbols, &rrctaps, &mut state)
     }
 
     #[test]

--- a/src/io/raw_iq.rs
+++ b/src/io/raw_iq.rs
@@ -31,7 +31,7 @@ impl<R: Read + Send> IQInput<R> {
     ///
     /// # Example
     ///
-    /// ```no-run
+    /// ```no_run
     /// use std::fs::File;
     /// use std::io::BufReader;
     /// use comms_rs::io::raw_iq::IQInput;
@@ -92,7 +92,7 @@ impl<R: Read + Send> IQBatchInput<R> {
     ///
     /// # Example
     ///
-    /// ```no-run
+    /// ```no_run
     /// use std::fs::File;
     /// use comms_rs::io::raw_iq::IQBatchInput;
     ///
@@ -154,7 +154,7 @@ impl<W: Write + Send> IQOutput<W> {
     ///
     /// # Example
     ///
-    /// ```no-run
+    /// ```no_run
     /// use std::fs::File;
     /// use std::io::BufWriter;
     /// use comms_rs::io::raw_iq::IQOutput;
@@ -195,7 +195,7 @@ impl<W: Write + Send> IQBatchOutput<W> {
     ///
     /// # Example
     ///
-    /// ```no-run
+    /// ```no_run
     /// use std::fs::File;
     /// use comms_rs::io::raw_iq::IQBatchOutput;
     ///

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -531,7 +531,7 @@ mod test {
                 &mut self,
                 input: &Arc<Vec<u32>>,
             ) -> Result<Arc<Vec<u32>>, NodeError> {
-                let mut y = Arc::clone(&input);
+                let mut y = Arc::clone(input);
                 for z in Arc::make_mut(&mut y).iter_mut() {
                     *z += 1;
                 }
@@ -624,7 +624,7 @@ mod test {
                 &mut self,
                 x: &Arc<Vec<i16>>,
             ) -> Result<Arc<Vec<i16>>, NodeError> {
-                let mut y = Arc::clone(&x);
+                let mut y = Arc::clone(x);
                 for z in Arc::make_mut(&mut y).iter_mut() {
                     *z = z.saturating_add(1);
                 }
@@ -715,7 +715,7 @@ mod test {
                 &mut self,
                 x: &Arc<Vec<i16>>,
             ) -> Result<Arc<Vec<i16>>, NodeError> {
-                let mut y = Arc::clone(&x);
+                let mut y = Arc::clone(x);
                 for z in Arc::make_mut(&mut y).iter_mut() {
                     *z = z.saturating_add(1);
                 }

--- a/src/prns.rs
+++ b/src/prns.rs
@@ -162,7 +162,7 @@ mod test {
                     assert_eq!(self.statemap.len(), 255);
                     return None;
                 } else {
-                    self.statemap.insert(self.state, 1 as u8);
+                    self.statemap.insert(self.state, 1_u8);
                 }
 
                 let fb_bit =
@@ -176,7 +176,7 @@ mod test {
         }
 
         let mut prngen = TestPrnsGenerator {
-            poly_mask: 0xB8 as u8,
+            poly_mask: 0xB8_u8,
             state: 0x01,
             statemap: HashMap::new(),
         };
@@ -189,7 +189,7 @@ mod test {
     #[test]
     // A test to verify the PrnsNode matches the PRBS7 output.
     fn test_prns_node() {
-        let mut mynode = PrnsNode::new(0xC0 as u8, 0x01);
+        let mut mynode = PrnsNode::new(0xC0_u8, 0x01);
         #[derive(Node)]
         struct CheckNode {
             input: NodeReceiver<u8>,

--- a/src/pulse.rs
+++ b/src/pulse.rs
@@ -85,8 +85,7 @@ where
         &mut self,
         input: &Complex<T>,
     ) -> Result<Vec<Complex<T>>, NodeError> {
-        let mut output = Vec::new();
-        output.push(fir(input, &self.taps, &mut self.state));
+        let mut output = vec![fir(input, &self.taps, &mut self.state)];
         for _ in 0..&self.sam_per_sym - 1 {
             output.push(fir(&Complex::zero(), &self.taps, &mut self.state));
         }

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -156,7 +156,7 @@ pub fn rc_taps<T>(
 where
     T: Copy + Num + num_traits::NumCast,
 {
-    if beta < 0.0 || beta > 1.0 {
+    if !(0.0..=1.0).contains(&beta) {
         return Err(MathError::InvalidRolloffError);
     };
 
@@ -226,7 +226,7 @@ pub fn rrc_taps<T>(
 where
     T: Copy + Num + num_traits::NumCast,
 {
-    if beta < 0.0 || beta > 1.0 {
+    if !(0.0..=1.0).contains(&beta) {
         return Err(MathError::InvalidRolloffError);
     };
 
@@ -309,7 +309,7 @@ pub fn qfilt_taps(
     alpha: f64,
     sam_per_sym: u32,
 ) -> Result<Vec<f64>, MathError> {
-    if alpha < 0.0 || alpha > 1.0 {
+    if !(0.0..=1.0).contains(&alpha) {
         return Err(MathError::InvalidRolloffError);
     };
 

--- a/src/util/math.rs
+++ b/src/util/math.rs
@@ -341,6 +341,7 @@ pub fn qfilt_taps(
     Ok(output)
 }
 
+#[allow(clippy::excessive_precision)]
 #[cfg(test)]
 mod test {
     use crate::util::math;

--- a/src/util/rand_node.rs
+++ b/src/util/rand_node.rs
@@ -193,7 +193,7 @@ mod test {
             }
 
             pub fn run(&mut self, x: f64) -> Result<(), NodeError> {
-                assert!(x >= 1.0 && x <= 2.0);
+                assert!((1.0..=2.0).contains(&x));
                 Ok(())
             }
         }


### PR DESCRIPTION
I ran:

```
$ cargo +nightly clippy --fix -Z unstable-options
$ cargo clippy --tests
$ cargo doc
```

and fixed or ignored warnings until I stopped seeing them. I expand on individual warnings in each commit.